### PR TITLE
css fix to Y scrollbar appearing in some cases.

### DIFF
--- a/css/diff2html.css
+++ b/css/diff2html.css
@@ -75,6 +75,7 @@
 
 .d2h-file-diff {
     overflow-x: scroll;
+    overflow-y: hidden;
 }
 
 .d2h-file-side-diff {


### PR DESCRIPTION
In some big diff cases where x scrollbar will bring out y scroll bar and this can fix this css issue.

<img width="959" alt="screen shot 2015-07-14 at 5 23 37 pm" src="https://cloud.githubusercontent.com/assets/5281068/8688139/1b2f4634-2a4d-11e5-87e6-ac430c70b992.png">
