### PR TITLE
Better regexp to handle unified diff header

### DIFF
--- a/src/diff-parser.js
+++ b/src/diff-parser.js
@@ -152,10 +152,10 @@
       var values = [];
       if (utils.startsWith(line, 'diff')) {
         startFile();
-      } else if (currentFile && !currentFile.oldName && (values = /^--- a\/(\S+).*$/.exec(line))) {
+      } else if (currentFile && !currentFile.oldName && (values = /^--- [aiwco]\/(.+)$/.exec(line))) {
         currentFile.oldName = values[1];
         currentFile.language = getExtension(currentFile.oldName, currentFile.language);
-      } else if (currentFile && !currentFile.newName && (values = /^\+\+\+ [b]?\/(\S+).*$/.exec(line))) {
+      } else if (currentFile && !currentFile.newName && (values = /^\+\+\+ [biwco]?\/(.+)$/.exec(line))) {
         currentFile.newName = values[1];
         currentFile.language = getExtension(currentFile.newName, currentFile.language);
       } else if (currentFile && utils.startsWith(line, '@@')) {


### PR DESCRIPTION
This addresses issue #20. According to my investigation, the git diff format doesn't include the timestamp at the end (as a regular unified diff), which makes it safe to parse as the filename everything until the end.

Also, I added more prefix, git uses other prefixes rather than `a` or `b` [if the config setting `diff.mnemonicprefix` is set to `true`](https://www.kernel.org/pub/software/scm/git/docs/git-config.html). So it makes sense to allow them too.

Let me know your thoughts!