### PR TITLE
A more object oriented approach

### DIFF
--- a/src/html-printer.js
+++ b/src/html-printer.js
@@ -7,14 +7,15 @@
 
 (function(ctx, undefined) {
 
-  var lineByLinePrinter = require('./line-by-line-printer.js').LineByLinePrinter;
+  var LineByLinePrinter = require('./line-by-line-printer.js').LineByLinePrinter;
   var sideBySidePrinter = require('./side-by-side-printer.js').SideBySidePrinter;
 
   function HtmlPrinter() {
   }
 
   HtmlPrinter.prototype.generateLineByLineJsonHtml = function(diffFiles, config) {
-    return lineByLinePrinter.generateLineByLineJsonHtml(diffFiles, config);
+    var lineByLinePrinter = new LineByLinePrinter(config);
+    return lineByLinePrinter.generateLineByLineJsonHtml(diffFiles);
   };
 
   HtmlPrinter.prototype.generateSideBySideJsonHtml = sideBySidePrinter.generateSideBySideJsonHtml;

--- a/src/html-printer.js
+++ b/src/html-printer.js
@@ -13,7 +13,9 @@
   function HtmlPrinter() {
   }
 
-  HtmlPrinter.prototype.generateLineByLineJsonHtml = lineByLinePrinter.generateLineByLineJsonHtml;
+  HtmlPrinter.prototype.generateLineByLineJsonHtml = function(diffFiles, config) {
+    return lineByLinePrinter.generateLineByLineJsonHtml(diffFiles, config);
+  };
 
   HtmlPrinter.prototype.generateSideBySideJsonHtml = sideBySidePrinter.generateSideBySideJsonHtml;
 

--- a/src/line-by-line-printer.js
+++ b/src/line-by-line-printer.js
@@ -12,17 +12,18 @@
   var utils = require('./utils.js').Utils;
   var Rematch = require('./rematch.js').Rematch;
 
-  function LineByLinePrinter() {
+  function LineByLinePrinter(config) {
+    this.config = config;
   }
 
-  LineByLinePrinter.prototype.generateLineByLineJsonHtml = function(diffFiles, config) {
+  LineByLinePrinter.prototype.generateLineByLineJsonHtml = function(diffFiles) {
     self = this;
     return '<div class="d2h-wrapper">\n' +
       diffFiles.map(function(file) {
 
         var diffs;
         if (file.blocks.length) {
-          diffs = self.generateFileHtml(file, config);
+          diffs = self.generateFileHtml(file);
         } else {
           diffs = self.generateEmptyDiff();
         }
@@ -59,7 +60,7 @@
     return Rematch.distance(amod, bmod);
   });
 
-  LineByLinePrinter.prototype.generateFileHtml = function(file, config) {
+  LineByLinePrinter.prototype.generateFileHtml = function(file) {
     self = this;
     return file.blocks.map(function(block) {
 
@@ -76,7 +77,7 @@
         var matches;
         var insertType;
         var deleteType;
-        var doMatching = config.matching === "lines" || config.matching === "words";
+        var doMatching = self.config.matching === "lines" || self.config.matching === "words";
         if (doMatching) {
           matches = matcher(oldLines, newLines);
           insertType = diffParser.LINE_TYPE.INSERT_CHANGES;
@@ -99,8 +100,8 @@
               oldLine = oldLines[j];
               newLine = newLines[j];
 
-              config.isCombined = file.isCombined;
-              var diff = printerUtils.diffHighlight(oldLine.content, newLine.content, config);
+              self.config.isCombined = file.isCombined;
+              var diff = printerUtils.diffHighlight(oldLine.content, newLine.content, self.config);
 
               processedOldLines +=
                 self.generateLineHtml(deleteType, oldLine.oldNumber, oldLine.newNumber,
@@ -198,6 +199,6 @@
       '</tr>\n';
   }
 
-  module.exports['LineByLinePrinter'] = new LineByLinePrinter();
+  module.exports['LineByLinePrinter'] = LineByLinePrinter;
 
 })(this);

--- a/src/line-by-line-printer.js
+++ b/src/line-by-line-printer.js
@@ -16,14 +16,15 @@
   }
 
   LineByLinePrinter.prototype.generateLineByLineJsonHtml = function(diffFiles, config) {
+    self = this;
     return '<div class="d2h-wrapper">\n' +
       diffFiles.map(function(file) {
 
         var diffs;
         if (file.blocks.length) {
-          diffs = generateFileHtml(file, config);
+          diffs = self.generateFileHtml(file, config);
         } else {
-          diffs = generateEmptyDiff();
+          diffs = self.generateEmptyDiff();
         }
 
         return '<div id="' + printerUtils.getHtmlId(file) + '" class="d2h-file-wrapper" data-lang="' + file.language + '">\n' +
@@ -58,7 +59,8 @@
     return Rematch.distance(amod, bmod);
   });
 
-  function generateFileHtml(file, config) {
+  LineByLinePrinter.prototype.generateFileHtml = function(file, config) {
+    self = this;
     return file.blocks.map(function(block) {
 
       var lines = '<tr>\n' +
@@ -101,15 +103,15 @@
               var diff = printerUtils.diffHighlight(oldLine.content, newLine.content, config);
 
               processedOldLines +=
-                generateLineHtml(deleteType, oldLine.oldNumber, oldLine.newNumber,
+                self.generateLineHtml(deleteType, oldLine.oldNumber, oldLine.newNumber,
                   diff.first.line, diff.first.prefix);
               processedNewLines +=
-                generateLineHtml(insertType, newLine.oldNumber, newLine.newNumber,
+                self.generateLineHtml(insertType, newLine.oldNumber, newLine.newNumber,
                   diff.second.line, diff.second.prefix);
             }
 
             lines += processedOldLines + processedNewLines;
-            lines += processLines(oldLines.slice(common), newLines.slice(common));
+            lines += self.processLines(oldLines.slice(common), newLines.slice(common));
 
             processedOldLines = [];
             processedNewLines = [];
@@ -127,9 +129,9 @@
           processChangeBlock();
         }
         if (line.type == diffParser.LINE_TYPE.CONTEXT) {
-          lines += generateLineHtml(line.type, line.oldNumber, line.newNumber, escapedLine);
+          lines += self.generateLineHtml(line.type, line.oldNumber, line.newNumber, escapedLine);
         } else if (line.type == diffParser.LINE_TYPE.INSERTS && !oldLines.length) {
-          lines += generateLineHtml(line.type, line.oldNumber, line.newNumber, escapedLine);
+          lines += self.generateLineHtml(line.type, line.oldNumber, line.newNumber, escapedLine);
         } else if (line.type == diffParser.LINE_TYPE.DELETES) {
           oldLines.push(line);
         } else if (line.type == diffParser.LINE_TYPE.INSERTS && !!oldLines.length) {
@@ -146,25 +148,25 @@
     }).join('\n');
   }
 
-  function processLines(oldLines, newLines) {
+  LineByLinePrinter.prototype.processLines = function(oldLines, newLines) {
     var lines = '';
 
     for (j = 0; j < oldLines.length; j++) {
       var oldLine = oldLines[j];
       var oldEscapedLine = utils.escape(oldLine.content);
-      lines += generateLineHtml(oldLine.type, oldLine.oldNumber, oldLine.newNumber, oldEscapedLine);
+      lines += this.generateLineHtml(oldLine.type, oldLine.oldNumber, oldLine.newNumber, oldEscapedLine);
     }
 
     for (j = 0; j < newLines.length; j++) {
       var newLine = newLines[j];
       var newEscapedLine = utils.escape(newLine.content);
-      lines += generateLineHtml(newLine.type, newLine.oldNumber, newLine.newNumber, newEscapedLine);
+      lines += this.generateLineHtml(newLine.type, newLine.oldNumber, newLine.newNumber, newEscapedLine);
     }
 
     return lines;
   }
 
-  function generateLineHtml(type, oldNumber, newNumber, content, prefix) {
+  LineByLinePrinter.prototype.generateLineHtml = function(type, oldNumber, newNumber, content, prefix) {
     var htmlPrefix = '';
     if (prefix) {
       htmlPrefix = '<span class="d2h-code-line-prefix">' + prefix + '</span>';
@@ -186,7 +188,7 @@
       '</tr>\n';
   }
 
-  function generateEmptyDiff() {
+  LineByLinePrinter.prototype.generateEmptyDiff = function() {
     return '<tr>\n' +
       '  <td class="' + diffParser.LINE_TYPE.INFO + '">' +
       '    <div class="d2h-code-line ' + diffParser.LINE_TYPE.INFO + '">' +


### PR DESCRIPTION
Hi,

I was trying to do something (which will come in further PRs) and I found that I needed to pass `config` all around the method calls. I tried to improve the `LineByLinePrinter` to use a more object oriented approach and pass the config only once in the constructor and be able to use it in all the functions. If we decide we like this I can then do it for `SideBySidePrinter` too.

I split the work in two commits so it's easier to review. In one I do the infrastructural change and in the other one I actually use the new changes by using a proper constructor.

Let me know your thoughts!