### PR TITLE
Adds unit tests using node-unit

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "devDependencies": {
     "webpack": "1.12.*",
     "uglifyjs": "2.4.*",
-    "less": "2.5.*"
+    "less": "2.5.*",
+    "nodeunit": "^0.9.1"
   },
   "license": "MIT",
   "files": [

--- a/tests/line-by-line-tests.js
+++ b/tests/line-by-line-tests.js
@@ -1,0 +1,18 @@
+var LineByLinePrinter = require('../src/line-by-line-printer.js').LineByLinePrinter;
+
+module.exports = {
+  testGenerateEmptyDiff: function (test) {
+    var lineByLinePrinter = new LineByLinePrinter({});
+    var fileHtml = lineByLinePrinter._generateEmptyDiff();
+    var expected = '<tr>\n' +
+      '  <td class="d2h-info">' +
+      '    <div class="d2h-code-line d2h-info">' +
+      'File without changes' +
+      '    </div>' +
+      '  </td>\n' +
+      '</tr>\n';
+
+    test.equal(expected, fileHtml);
+    test.done();
+  }
+};

--- a/tests/side-by-side-printer-tests.js
+++ b/tests/side-by-side-printer-tests.js
@@ -1,0 +1,19 @@
+var SideBySidePrinter = require('../src/side-by-side-printer.js').SideBySidePrinter;
+
+module.exports = {
+  testGenerateEmptyDiff: function (test) {
+    var sideBySidePrinter = new SideBySidePrinter({});
+    var fileHtml = sideBySidePrinter.generateEmptyDiff();
+    var expectedRight = '';
+    var expectedLeft = '<tr>\n' +
+      '  <td class="d2h-info">' +
+      '    <div class="d2h-code-side-line d2h-info">' +
+      'File without changes' +
+      '    </div>' +
+      '  </td>\n' +
+      '</tr>\n';
+    test.equal(expectedRight, fileHtml.right);
+    test.equal(expectedLeft, fileHtml.left);
+    test.done();
+  }
+};


### PR DESCRIPTION
First approach to include unit tests in the code using node-unit.

- Adds node unit dependency
- Adds 2 very basic tests for LineByLine and SideBySide printers

This is more like a "Request For Comments" :)

I'm not sure if you want this at all, or if you were thinking of another library/way of testing. In order to test this you just need to `npm install` to install the `node-unit` package and then just:

    nodeunit tests

from the terminal in the project's root.

Let me know your thoughts.