### PR TITLE
Fixes prefix bug on side by side diff

### DIFF
--- a/src/side-by-side-printer.js
+++ b/src/side-by-side-printer.js
@@ -153,7 +153,7 @@
 
       for (var i = 0; i < block.lines.length; i++) {
         var line = block.lines[i];
-        var prefix = line[0];
+        var prefix = line.content[0];
         var escapedLine = utils.escape(line.content.substr(1));
 
         if (line.type !== diffParser.LINE_TYPE.INSERTS &&


### PR DESCRIPTION
This bug caused `prefix` to always be undefined and the content of the side by side diff wasn't showing properly aligned. Maybe we can write a test for this :)