### PR TITLE
Refactors html code into methods for LineByLinePrinter

### DIFF
--- a/test/line-by-line-tests.js
+++ b/test/line-by-line-tests.js
@@ -19,4 +19,46 @@ describe('LineByLinePrinter', function() {
       assert.equal(expected, fileHtml);
     });
   });
+  describe('_generateLineHtml', function() {
+    it('should work for insertions', function() {
+
+      var diffParser = require('../src/diff-parser.js').DiffParser;
+      var lineByLinePrinter = new LineByLinePrinter({});
+      var fileHtml = lineByLinePrinter._generateLineHtml(
+        diffParser.LINE_TYPE.INSERTS, '', 30, '+', 'test');
+      var expected = '<tr>\n' +
+      '  <td class="d2h-code-linenumber d2h-ins">' +
+      '    <div class="line-num1"></div>' +
+      '    <div class="line-num2">30</div>' +
+      '  </td>\n' +
+      '  <td class="d2h-ins">' +
+      '    <div class="d2h-code-line d2h-ins">' +
+      '<span class="d2h-code-line-prefix">test</span>' +
+      '<span class="d2h-code-line-ctn">+</span></div>' +
+      '  </td>\n' +
+      '</tr>\n';
+
+      assert.equal(expected, fileHtml);
+    });
+    it('should work for deletions', function() {
+
+      var diffParser = require('../src/diff-parser.js').DiffParser;
+      var lineByLinePrinter = new LineByLinePrinter({});
+      var fileHtml = lineByLinePrinter._generateLineHtml(
+        diffParser.LINE_TYPE.DELETES, 30, '', '-', 'test');
+      var expected = '<tr>\n' +
+      '  <td class="d2h-code-linenumber d2h-del">' +
+      '    <div class="line-num1">30</div>' +
+      '    <div class="line-num2"></div>' +
+      '  </td>\n' +
+      '  <td class="d2h-del">' +
+      '    <div class="d2h-code-line d2h-del">' +
+      '<span class="d2h-code-line-prefix">test</span>' +
+      '<span class="d2h-code-line-ctn">-</span></div>' +
+      '  </td>\n' +
+      '</tr>\n';
+
+      assert.equal(expected, fileHtml);
+    });
+  });
 });


### PR DESCRIPTION
Doing this to improve readability and to separate the _html templating_ from the logic. If accepted I can do the same for SideBySide after that.

I think we should move towards a point where the library user can easily modify/override the generated html to their own needs. As a user I know I would like this.