### PR TITLE
Fix line count when EOF is added to file

### DIFF
--- a/src/diff-parser.js
+++ b/src/diff-parser.js
@@ -122,7 +122,9 @@
       }
     };
 
-    var diffLines = diffInput.split('\n');
+    var diffLines =
+      diffInput.replace(/\\ No newline at end of file/g, '')
+        .split('\n');
 
     /* Diff */
     var oldMode = /^old mode (\d{6})/;

--- a/test/diff2html-tests.js
+++ b/test/diff2html-tests.js
@@ -22,5 +22,54 @@ describe('Diff2Html', function() {
       assert.equal('sample', file1.newName);
       assert.equal(1, file1.blocks.length);
     });
+
+    // Test case for issue #49
+    it('should parse diff with added EOF', function() {
+      var diff =
+        'diff --git a/sample.scala b/sample.scala\n' +
+        'index b583263..8b2fc3e 100644\n' +
+        '--- a/b583263..8b2fc3e\n' +
+        '+++ b/8b2fc3e\n' +
+        '@@ -50,5 +50,7 @@ case class Response[+A](value: Option[A],\n' +
+        ' object ResponseErrorCode extends JsonEnumeration {\n' +
+        '  val NoError, ServiceError, JsonError,\n' +
+        '  InvalidPermissions, MissingPermissions, GenericError,\n' +
+        '-  TokenRevoked, MissingToken = Value\n' +
+        '-}\n' +
+        '\\ No newline at end of file\n' +
+        '+  TokenRevoked, MissingToken,\n' +
+        '+  IndexLock, RepositoryError, NotValidRepo, PullRequestNotMergeable, BranchError,\n' +
+        '+  PluginError, CodeParserError, EngineError = Value\n' +
+        '+}\n';
+      var result = Diff2Html.getJsonFromDiff(diff);
+
+      assert.equal(50, result[0].blocks[0].lines[0].oldNumber);
+      assert.equal(50, result[0].blocks[0].lines[0].newNumber);
+
+      assert.equal(51, result[0].blocks[0].lines[1].oldNumber);
+      assert.equal(51, result[0].blocks[0].lines[1].newNumber);
+
+      assert.equal(52, result[0].blocks[0].lines[2].oldNumber);
+      assert.equal(52, result[0].blocks[0].lines[2].newNumber);
+
+      assert.equal(53, result[0].blocks[0].lines[3].oldNumber);
+      assert.equal(null, result[0].blocks[0].lines[3].newNumber);
+
+      assert.equal(54, result[0].blocks[0].lines[4].oldNumber);
+      assert.equal(null, result[0].blocks[0].lines[4].newNumber);
+
+      assert.equal(null, result[0].blocks[0].lines[5].oldNumber);
+      assert.equal(53, result[0].blocks[0].lines[5].newNumber);
+
+      assert.equal(null, result[0].blocks[0].lines[6].oldNumber);
+      assert.equal(54, result[0].blocks[0].lines[6].newNumber);
+
+
+      assert.equal(null, result[0].blocks[0].lines[7].oldNumber);
+      assert.equal(55, result[0].blocks[0].lines[7].newNumber);
+
+      assert.equal(null, result[0].blocks[0].lines[8].oldNumber);
+      assert.equal(56, result[0].blocks[0].lines[8].newNumber);
+    });
   });
 });


### PR DESCRIPTION
Removes '\\ No newline at end of file' information from the diff lines.
The test case is based on Bitbucket's diff attached to issue #49.