### PR TITLE
Fix parsing on Windows

### DIFF
--- a/src/diff-parser.js
+++ b/src/diff-parser.js
@@ -124,6 +124,7 @@
 
     var diffLines =
       diffInput.replace(/\\ No newline at end of file/g, '')
+        .replace(/\r\n?/g, '\n')
         .split('\n');
 
     /* Diff */

--- a/test/diff-parser-tests.js
+++ b/test/diff-parser-tests.js
@@ -5,7 +5,7 @@ var DiffParser = require('../src/diff-parser.js').DiffParser;
 describe('DiffParser', function() {
   describe('generateDiffJson', function() {
 
-    it('should parse linux with \n diff', function() {
+    it('should parse unix with \n diff', function() {
       var diff =
         'diff --git a/sample b/sample\n' +
         'index 0000001..0ddf2ba\n' +
@@ -14,14 +14,7 @@ describe('DiffParser', function() {
         '@@ -1 +1 @@\n' +
         '-test\n' +
         '+test1r\n';
-      var result = Diff2Html.getJsonFromDiff(diff);
-      var file1 = result[0];
-      assert.equal(1, result.length);
-      assert.equal(1, file1.addedLines);
-      assert.equal(1, file1.deletedLines);
-      assert.equal('sample', file1.oldName);
-      assert.equal('sample', file1.newName);
-      assert.equal(1, file1.blocks.length);
+      checkDiffSample(diff)
     });
 
     it('should parse windows with \r\n diff', function() {
@@ -32,7 +25,35 @@ describe('DiffParser', function() {
         '+++ b/sample\r\n' +
         '@@ -1 +1 @@\r\n' +
         '-test\r\n' +
+        '+test1r\r\n';
+      checkDiffSample(diff)
+    });
+
+    it('should parse old os x with \r diff', function() {
+      var diff =
+        'diff --git a/sample b/sample\r' +
+        'index 0000001..0ddf2ba\r' +
+        '--- a/sample\r' +
+        '+++ b/sample\r' +
+        '@@ -1 +1 @@\r' +
+        '-test\r' +
+        '+test1r\r';
+      checkDiffSample(diff)
+    });
+
+    it('should parse mixed eols diff', function() {
+      var diff =
+        'diff --git a/sample b/sample\n' +
+        'index 0000001..0ddf2ba\r\n' +
+        '--- a/sample\r' +
+        '+++ b/sample\r\n' +
+        '@@ -1 +1 @@\n' +
+        '-test\r' +
         '+test1r\n';
+      checkDiffSample(diff)
+    });
+
+    function checkDiffSample(diff) {
       var result = Diff2Html.getJsonFromDiff(diff);
       var file1 = result[0];
       assert.equal(1, result.length);
@@ -41,7 +62,7 @@ describe('DiffParser', function() {
       assert.equal('sample', file1.oldName);
       assert.equal('sample', file1.newName);
       assert.equal(1, file1.blocks.length);
-    });
+    }
 
   });
 });

--- a/test/diff-parser-tests.js
+++ b/test/diff-parser-tests.js
@@ -1,0 +1,47 @@
+var assert = require('assert');
+
+var DiffParser = require('../src/diff-parser.js').DiffParser;
+
+describe('DiffParser', function() {
+  describe('generateDiffJson', function() {
+
+    it('should parse linux with \n diff', function() {
+      var diff =
+        'diff --git a/sample b/sample\n' +
+        'index 0000001..0ddf2ba\n' +
+        '--- a/sample\n' +
+        '+++ b/sample\n' +
+        '@@ -1 +1 @@\n' +
+        '-test\n' +
+        '+test1r\n';
+      var result = Diff2Html.getJsonFromDiff(diff);
+      var file1 = result[0];
+      assert.equal(1, result.length);
+      assert.equal(1, file1.addedLines);
+      assert.equal(1, file1.deletedLines);
+      assert.equal('sample', file1.oldName);
+      assert.equal('sample', file1.newName);
+      assert.equal(1, file1.blocks.length);
+    });
+
+    it('should parse windows with \r\n diff', function() {
+      var diff =
+        'diff --git a/sample b/sample\r\n' +
+        'index 0000001..0ddf2ba\r\n' +
+        '--- a/sample\r\n' +
+        '+++ b/sample\r\n' +
+        '@@ -1 +1 @@\r\n' +
+        '-test\r\n' +
+        '+test1r\n';
+      var result = Diff2Html.getJsonFromDiff(diff);
+      var file1 = result[0];
+      assert.equal(1, result.length);
+      assert.equal(1, file1.addedLines);
+      assert.equal(1, file1.deletedLines);
+      assert.equal('sample', file1.oldName);
+      assert.equal('sample', file1.newName);
+      assert.equal(1, file1.blocks.length);
+    });
+
+  });
+});


### PR DESCRIPTION
Fixes #57 

Replace windows EOL by Unix EOL

It should work for `\r\n`, `\r` and `\n`.

@pbu88 what do you think?