### PR TITLE
Add support for output of `svn diff --git`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ diff2html generates pretty HTML diffs from git or unified diff output.
 
 * Easy code selection
 
+* Support `svn diff --git` output
+
 ## Online Example
 
 > Go to [diff2html](https://diff2html.xyz/)
@@ -100,6 +102,8 @@ The HTML output accepts a Javascript object with configuration. Possible options
   - `matchingMaxComparisons`: perform at most this much comparisons for line matching a block of changes, default is `2500`
   - `templates`: object with previously compiled templates to replace parts of the html
   - `rawTemplates`: object with raw not compiled templates to replace parts of the html
+  - `ignoreSvnPropertyChange`: If you use `svn diff --git`, and add or delete a binary file, you will get two file change records in output. Set `ignoreSvnPropertyChange = true` will help you ignore the second record.
+   
   > For more information regarding the possible templates look into [src/templates](https://github.com/rtfpessoa/diff2html/tree/master/src/templates)
 
 ## Diff2HtmlUI Helper

--- a/src/diff-parser.js
+++ b/src/diff-parser.js
@@ -455,7 +455,7 @@
    * You proberly do not want to see the second record. So will provide an `ignoreSvnPropertyChange` option to do that for you.
    */
   function dropSvnPropertyChangeFiles(files) {
-    const GIT_BINNARY_HEADER = 'GIT binary patch';
+    const GIT_BINARY_HEADER = 'GIT binary patch';
     const PROPERTY_CHANGE_HEADER = 'Property changes on:';
     var ret = [];
     for (var i = 0; i < files.length - 1; i++) {
@@ -464,7 +464,7 @@
 
       ret.push(file);
       if (file.blocks.length > 0 &&
-        utils.startsWith(file.blocks[0].header, GIT_BINNARY_HEADER) &&
+        utils.startsWith(file.blocks[0].header, GIT_BINARY_HEADER) &&
         nextFile.blocks.length > 0 &&
         utils.startsWith(nextFile.blocks[0].header, PROPERTY_CHANGE_HEADER) &&
         file.name === nextFile.name &&

--- a/src/diff-parser.js
+++ b/src/diff-parser.js
@@ -223,7 +223,7 @@
     var svnNullFileMode = /^(.+)(\s+)(\(nonexistent\))$/;
     var svnWithVersionFileMode = /^(.+)(\s+)(\(revision\s+\d+\))$/;
 
-    /* if we use command `svn diff --git`. we wiil get header like that:
+    /* if we use command `svn diff --git`. we will get header like that:
      *
      * ```
      * diff --git a/color_doc.docx b/color_doc.docx
@@ -320,7 +320,6 @@
           (values = getSrcFilename(line, config))
         ) {
           checkSvnFileMode(values, true);
-          //          currentFile.oldName = values;
           currentFile.language = getExtension(currentFile.oldName, currentFile.language);
           return;
         }

--- a/src/diff-parser.js
+++ b/src/diff-parser.js
@@ -457,10 +457,10 @@
   function dropSvnPropertyChangeFiles(files) {
     const GIT_BINNARY_HEADER = 'GIT binary patch';
     const PROPERTY_CHANGE_HEADER = 'Property changes on:';
-    let ret = new Array();
+    var ret = new Array();
     for (var i = 0; i < files.length - 1; i++) {
-      let file = files[i];
-      let nextFile = files[i + 1];
+      var file = files[i];
+      var nextFile = files[i + 1];
 
       ret.push(file);
       if (file.blocks.length > 0

--- a/src/diff-parser.js
+++ b/src/diff-parser.js
@@ -5,7 +5,7 @@
  *
  */
 
-(function () {
+(function() {
   var utils = require('./utils.js').Utils;
 
   var LINE_TYPE = {
@@ -22,7 +22,7 @@
 
   DiffParser.prototype.LINE_TYPE = LINE_TYPE;
 
-  DiffParser.prototype.generateDiffJson = function (diffInput, configuration) {
+  DiffParser.prototype.generateDiffJson = function(diffInput, configuration) {
     var config = configuration || {};
 
     var files = [];
@@ -237,28 +237,27 @@
     function checkSvnFileMode(fileName, isOld) {
       var result = null;
       if (isOld) {
-        if (result = svnNullFileMode.exec(fileName)) {
+        if ((result = svnNullFileMode.exec(fileName))) {
           currentFile.oldName = result[1];
           //          currentFile.isNew   = true;
-        } else if (result = svnWithVersionFileMode.exec(fileName)) {
+        } else if ((result = svnWithVersionFileMode.exec(fileName))) {
           currentFile.oldName = result[1];
         } else {
           currentFile.oldName = fileName;
         }
       } else {
-        if (result = svnNullFileMode.exec(fileName)) {
+        if ((result = svnNullFileMode.exec(fileName))) {
           currentFile.newName = result[1];
           //          currentFile.isDeleted = true;
-        } else if (result = svnWithVersionFileMode.exec(fileName)) {
+        } else if ((result = svnWithVersionFileMode.exec(fileName))) {
           currentFile.newName = result[1];
         } else {
           currentFile.newName = fileName;
         }
-
       }
     }
 
-    diffLines.forEach(function (line, lineIndex) {
+    diffLines.forEach(function(line, lineIndex) {
       // Unmerged paths, and possibly other non-diffable files
       // https://github.com/scottgonzalez/pretty-diff/issues/11
       // Also, remove some useless lines
@@ -317,8 +316,9 @@
          * --- 2002-02-21 23:30:39.942229878 -0800
          */
         if (currentFile && !currentFile.oldName &&
-          utils.startsWith(line, '--- ') && (values = getSrcFilename(line, config))) {
-
+          utils.startsWith(line, '--- ') &&
+          (values = getSrcFilename(line, config))
+        ) {
           checkSvnFileMode(values, true);
           //          currentFile.oldName = values;
           currentFile.language = getExtension(currentFile.oldName, currentFile.language);
@@ -427,8 +427,9 @@
     saveBlock();
     saveFile();
 
-    if (configuration.ignoreSvnPropertyChange)
+    if (config.ignoreSvnPropertyChange) {
       files = dropSvnPropertyChangeFiles(files);
+    }
     return files;
   };
 
@@ -457,18 +458,18 @@
   function dropSvnPropertyChangeFiles(files) {
     const GIT_BINNARY_HEADER = 'GIT binary patch';
     const PROPERTY_CHANGE_HEADER = 'Property changes on:';
-    var ret = new Array();
+    var ret = [];
     for (var i = 0; i < files.length - 1; i++) {
       var file = files[i];
       var nextFile = files[i + 1];
 
       ret.push(file);
-      if (file.blocks.length > 0
-        && utils.startsWith(file.blocks[0].header, GIT_BINNARY_HEADER)
-        && nextFile.blocks.length > 0
-        && utils.startsWith(nextFile.blocks[0].header, PROPERTY_CHANGE_HEADER)
-        && file.name === nextFile.name
-        && (file.isDeleted === true || file.isNew === true)
+      if (file.blocks.length > 0 &&
+        utils.startsWith(file.blocks[0].header, GIT_BINNARY_HEADER) &&
+        nextFile.blocks.length > 0 &&
+        utils.startsWith(nextFile.blocks[0].header, PROPERTY_CHANGE_HEADER) &&
+        file.name === nextFile.name &&
+        (file.isDeleted === true || file.isNew === true)
       ) {
         i += 1;
       }
@@ -476,7 +477,6 @@
 
     return ret;
   }
-
 
   function getExtension(filename, language) {
     var nameSplit = filename.split('.');
@@ -486,7 +486,6 @@
 
     return language;
   }
-
 
   function getSrcFilename(line, cfg) {
     return _getFilename('---', line, cfg.srcPrefix);
@@ -513,7 +512,7 @@
     var values = FilenameRegExp.exec(line);
     if (values && values[1]) {
       filename = values[1];
-      var matchingPrefixes = prefixes.filter(function (p) {
+      var matchingPrefixes = prefixes.filter(function(p) {
         return filename.indexOf(p) === 0;
       });
 
@@ -532,6 +531,5 @@
   }
 
   module.exports.DiffParser = new DiffParser();
-})
-();
+})();
 

--- a/src/diff-parser.js
+++ b/src/diff-parser.js
@@ -239,7 +239,6 @@
       if (isOld) {
         if ((result = svnNullFileMode.exec(fileName))) {
           currentFile.oldName = result[1];
-          //          currentFile.isNew   = true;
         } else if ((result = svnWithVersionFileMode.exec(fileName))) {
           currentFile.oldName = result[1];
         } else {
@@ -248,7 +247,6 @@
       } else {
         if ((result = svnNullFileMode.exec(fileName))) {
           currentFile.newName = result[1];
-          //          currentFile.isDeleted = true;
         } else if ((result = svnWithVersionFileMode.exec(fileName))) {
           currentFile.newName = result[1];
         } else {
@@ -331,7 +329,6 @@
         if (currentFile && !currentFile.newName &&
           utils.startsWith(line, '+++ ') && (values = getDstFilename(line, config))) {
           checkSvnFileMode(values, false);
-          //          currentFile.newName = values;
           currentFile.language = getExtension(currentFile.newName, currentFile.language);
           return;
         }

--- a/test/diff-parser-tests.js
+++ b/test/diff-parser-tests.js
@@ -796,7 +796,6 @@ describe('DiffParser', function() {
       assert.equal('docx', file2.language);
     });
 
-
     it('should parse multiple files without ignoreSvnPropertyChange', function() {
       var diff = 'Index: trunk/README.md\n' +
         '===================================================================\n' +
@@ -843,10 +842,9 @@ describe('DiffParser', function() {
 
       var file4 = result[3];
       assert.equal('trunk/octofamily/momma_octocat.txt', file4.oldName);
-      assert.equal("/dev/null", file4.newName);
+      assert.equal('/dev/null', file4.newName);
       assert.equal(true, file4.isDeleted);
       assert.equal(true, file4.isGitDiff);
-
     });
   });
 });

--- a/test/diff-parser-tests.js
+++ b/test/diff-parser-tests.js
@@ -5,8 +5,7 @@ var DiffParser = require('../src/diff-parser.js').DiffParser;
 describe('DiffParser', function() {
   describe('generateDiffJson', function() {
     it('should parse unix with \n diff', function() {
-      var diff =
-        'diff --git a/sample b/sample\n' +
+      var diff = 'diff --git a/sample b/sample\n' +
         'index 0000001..0ddf2ba\n' +
         '--- a/sample\n' +
         '+++ b/sample\n' +
@@ -17,8 +16,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse windows with \r\n diff', function() {
-      var diff =
-        'diff --git a/sample b/sample\r\n' +
+      var diff = 'diff --git a/sample b/sample\r\n' +
         'index 0000001..0ddf2ba\r\n' +
         '--- a/sample\r\n' +
         '+++ b/sample\r\n' +
@@ -29,8 +27,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse old os x with \r diff', function() {
-      var diff =
-        'diff --git a/sample b/sample\r' +
+      var diff = 'diff --git a/sample b/sample\r' +
         'index 0000001..0ddf2ba\r' +
         '--- a/sample\r' +
         '+++ b/sample\r' +
@@ -41,8 +38,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse mixed eols diff', function() {
-      var diff =
-        'diff --git a/sample b/sample\n' +
+      var diff = 'diff --git a/sample b/sample\n' +
         'index 0000001..0ddf2ba\r\n' +
         '--- a/sample\r' +
         '+++ b/sample\r\n' +
@@ -64,8 +60,7 @@ describe('DiffParser', function() {
     }
 
     it('should parse diff with special characters', function() {
-      var diff =
-        'diff --git "a/bla with \ttab.scala" "b/bla with \ttab.scala"\n' +
+      var diff = 'diff --git "a/bla with \ttab.scala" "b/bla with \ttab.scala"\n' +
         'index 4c679d7..e9bd385 100644\n' +
         '--- "a/bla with \ttab.scala"\n' +
         '+++ "b/bla with \ttab.scala"\n' +
@@ -85,8 +80,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff with prefix', function() {
-      var diff =
-        'diff --git "\tbla with \ttab.scala" "\tbla with \ttab.scala"\n' +
+      var diff = 'diff --git "\tbla with \ttab.scala" "\tbla with \ttab.scala"\n' +
         'index 4c679d7..e9bd385 100644\n' +
         '--- "\tbla with \ttab.scala"\n' +
         '+++ "\tbla with \ttab.scala"\n' +
@@ -95,7 +89,10 @@ describe('DiffParser', function() {
         '+cenas com ananas\n' +
         '+bananas';
 
-      var result = DiffParser.generateDiffJson(diff, {'srcPrefix': '\t', 'dstPrefix': '\t'});
+      var result = DiffParser.generateDiffJson(diff, {
+        'srcPrefix': '\t',
+        'dstPrefix': '\t'
+      });
       var file1 = result[0];
       assert.equal(1, result.length);
       assert.equal(2, file1.addedLines);
@@ -106,8 +103,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff with deleted file', function() {
-      var diff =
-        'diff --git a/src/var/strundefined.js b/src/var/strundefined.js\n' +
+      var diff = 'diff --git a/src/var/strundefined.js b/src/var/strundefined.js\n' +
         'deleted file mode 100644\n' +
         'index 04e16b0..0000000\n' +
         '--- a/src/var/strundefined.js\n' +
@@ -133,8 +129,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff with new file', function() {
-      var diff =
-        'diff --git a/test.js b/test.js\n' +
+      var diff = 'diff --git a/test.js b/test.js\n' +
         'new file mode 100644\n' +
         'index 0000000..e1e22ec\n' +
         '--- /dev/null\n' +
@@ -163,8 +158,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff with nested diff', function() {
-      var diff =
-        'diff --git a/src/offset.js b/src/offset.js\n' +
+      var diff = 'diff --git a/src/offset.js b/src/offset.js\n' +
         'index cc6ffb4..fa51f18 100644\n' +
         '--- a/src/offset.js\n' +
         '+++ b/src/offset.js\n' +
@@ -192,8 +186,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff with multiple blocks', function() {
-      var diff =
-        'diff --git a/src/attributes/classes.js b/src/attributes/classes.js\n' +
+      var diff = 'diff --git a/src/attributes/classes.js b/src/attributes/classes.js\n' +
         'index c617824..c8d1393 100644\n' +
         '--- a/src/attributes/classes.js\n' +
         '+++ b/src/attributes/classes.js\n' +
@@ -236,8 +229,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff with multiple files', function() {
-      var diff =
-        'diff --git a/src/core/init.js b/src/core/init.js\n' +
+      var diff = 'diff --git a/src/core/init.js b/src/core/init.js\n' +
         'index e49196a..50f310c 100644\n' +
         '--- a/src/core/init.js\n' +
         '+++ b/src/core/init.js\n' +
@@ -289,8 +281,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse combined diff', function() {
-      var diff =
-        'diff --combined describe.c\n' +
+      var diff = 'diff --combined describe.c\n' +
         'index fabadb8,cc95eb0..4866510\n' +
         '--- a/describe.c\n' +
         '+++ b/describe.c\n' +
@@ -334,8 +325,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diffs with copied files', function() {
-      var diff =
-        'diff --git a/index.js b/more-index.js\n' +
+      var diff = 'diff --git a/index.js b/more-index.js\n' +
         'dissimilarity index 5%\n' +
         'copy from index.js\n' +
         'copy to more-index.js\n';
@@ -354,8 +344,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diffs with moved files', function() {
-      var diff =
-        'diff --git a/more-index.js b/other-index.js\n' +
+      var diff = 'diff --git a/more-index.js b/other-index.js\n' +
         'similarity index 86%\n' +
         'rename from more-index.js\n' +
         'rename to other-index.js\n';
@@ -374,8 +363,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diffs correct line numbers', function() {
-      var diff =
-        'diff --git a/sample b/sample\n' +
+      var diff = 'diff --git a/sample b/sample\n' +
         'index 0000001..0ddf2ba\n' +
         '--- a/sample\n' +
         '+++ b/sample\n' +
@@ -400,8 +388,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse unified non git diff and strip timestamps off the headers', function() {
-      var diff =
-        '--- a/sample.js	2016-10-25 11:37:14.000000000 +0200\n' +
+      var diff = '--- a/sample.js	2016-10-25 11:37:14.000000000 +0200\n' +
         '+++ b/sample.js	2016-10-25 11:37:14.000000000 +0200\n' +
         '@@ -1 +1,2 @@\n' +
         '-test\n' +
@@ -424,8 +411,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse unified non git diff', function() {
-      var diff =
-        '--- a/sample.js\n' +
+      var diff = '--- a/sample.js\n' +
         '+++ b/sample.js\n' +
         '@@ -1 +1,2 @@\n' +
         '-test\n' +
@@ -448,8 +434,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse unified diff with multiple hunks and files', function() {
-      var diff =
-        '--- sample.js\n' +
+      var diff = '--- sample.js\n' +
         '+++ sample.js\n' +
         '@@ -1 +1,2 @@\n' +
         '-test\n' +
@@ -494,8 +479,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff with --- and +++ in the context lines', function() {
-      var diff =
-        '--- sample.js\n' +
+      var diff = '--- sample.js\n' +
         '+++ sample.js\n' +
         '@@ -1,8 +1,8 @@\n' +
         ' test\n' +
@@ -525,8 +509,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff without proper hunk headers', function() {
-      var diff =
-        '--- sample.js\n' +
+      var diff = '--- sample.js\n' +
         '+++ sample.js\n' +
         '@@ @@\n' +
         ' test';
@@ -547,8 +530,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse binary file diff', function() {
-      var diff =
-        'diff --git a/last-changes-config.png b/last-changes-config.png\n' +
+      var diff = 'diff --git a/last-changes-config.png b/last-changes-config.png\n' +
         'index 322248b..56fc1f2 100644\n' +
         '--- a/last-changes-config.png\n' +
         '+++ b/last-changes-config.png\n' +
@@ -567,8 +549,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff with --find-renames', function() {
-      var diff =
-        'diff --git a/src/test-bar.js b/src/test-baz.js\n' +
+      var diff = 'diff --git a/src/test-bar.js b/src/test-baz.js\n' +
         'similarity index 98%\n' +
         'rename from src/test-bar.js\n' +
         'rename to src/test-baz.js\n' +
@@ -599,8 +580,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse diff with prefix', function() {
-      var diff =
-        'diff --git "\tTest.scala" "\tScalaTest.scala"\n' +
+      var diff = 'diff --git "\tTest.scala" "\tScalaTest.scala"\n' +
         'similarity index 88%\n' +
         'rename from Test.scala\n' +
         'rename to ScalaTest.scala\n' +
@@ -642,7 +622,10 @@ describe('DiffParser', function() {
         ' }\n' +
         ' ';
 
-      var result = DiffParser.generateDiffJson(diff, {'srcPrefix': '\t', 'dstPrefix': '\t'});
+      var result = DiffParser.generateDiffJson(diff, {
+        'srcPrefix': '\t',
+        'dstPrefix': '\t'
+      });
       assert.equal(3, result.length);
 
       var file1 = result[0];
@@ -673,8 +656,7 @@ describe('DiffParser', function() {
     });
 
     it('should parse binary with content', function() {
-      var diff =
-        'diff --git a/favicon.png b/favicon.png\n' +
+      var diff = 'diff --git a/favicon.png b/favicon.png\n' +
         'deleted file mode 100644\n' +
         'index 2a9d516a5647205d7be510dd0dff93a3663eff6f..0000000000000000000000000000000000000000\n' +
         'GIT binary patch\n' +
@@ -729,9 +711,8 @@ describe('DiffParser', function() {
         [' function foo() {', '-var bar = "Whoops!";', '+var baz = "Whoops!";', ' }', ' ']);
     });
 
-    it('should parse `svn diff --git` content', function() {
-      var diff =
-        'Index: color_doc.docx\n' +
+    it('should ignore the property set record of `svn diff --git` with ignoreSvnPropertyChange = true', function() {
+      var diff = 'Index: color_doc.docx\n' +
         '===================================================================\n' +
         'diff --git a/color_doc.docx b/color_doc.docx\n' +
         'new file mode 10644\n' +
@@ -759,7 +740,9 @@ describe('DiffParser', function() {
         '+application/octet-stream\n' +
         '\\ No newline at end of property\n' +
         ' ';
-      var result = DiffParser.generateDiffJson(diff, {ignoreSvnPropertyChange: true});
+      var result = DiffParser.generateDiffJson(diff, {
+        ignoreSvnPropertyChange: true
+      });
       assert.equal(1, result.length);
 
       var file1 = result[0];
@@ -767,6 +750,103 @@ describe('DiffParser', function() {
       assert.equal('color_doc.docx', file1.newName);
       assert.equal(true, file1.isNew);
       assert.equal('10644', file1.newFileMode);
+    });
+
+    it('should parse `svn diff --git` content without ignoreSvnPropertyChange', function() {
+      var diff = 'Index: color_doc.docx\n' +
+        '===================================================================\n' +
+        'diff --git a/color_doc.docx b/color_doc.docx\n' +
+        'new file mode 10644\n' +
+        'GIT binary patch\n' +
+        'literal 296291\n' +
+        'zc%1CHV|b>|mmvJaPteH|b!;ac+w9n8$F^;E+_5|E*jC3@$F^-JoBsW0W@mS2->>`O\n' +
+        ' \n' +
+        'literal 0\n' +
+        'Hc$@<O00001\n' +
+        ' \n' +
+        'Index: color_doc.docx\n' +
+        '===================================================================\n' +
+        'diff --git a/color_doc.docx b/color_doc.docx\n' +
+        '--- a/color_doc.docx	(nonexistent)\n' +
+        '+++ b/color_doc.docx	(revision 10)\n' +
+        '\n' +
+        'Property changes on: color_doc.docx\n' +
+        '___________________________________________________________________\n' +
+        'Added: svn:executable\n' +
+        '## -0,0 +1 ##\n' +
+        '+*\n' +
+        '\\ No newline at end of property\n' +
+        'Added: svn:mime-type\n' +
+        '## -0,0 +1 ##\n' +
+        '+application/octet-stream\n' +
+        '\\ No newline at end of property\n' +
+        ' ';
+      var result = DiffParser.generateDiffJson(diff);
+      assert.equal(2, result.length);
+
+      var file1 = result[0];
+      assert.equal('color_doc.docx', file1.oldName);
+      assert.equal('color_doc.docx', file1.newName);
+      assert.equal(true, file1.isNew);
+      assert.equal('10644', file1.newFileMode);
+
+      var file2 = result[1];
+      assert.equal('color_doc.docx', file2.oldName);
+      assert.equal('color_doc.docx', file2.newName);
+      assert.equal('docx', file2.language);
+    });
+
+
+    it('should parse multiple files without ignoreSvnPropertyChange', function() {
+      var diff = 'Index: trunk/README.md\n' +
+        '===================================================================\n' +
+        'diff --git a/trunk/README.md b/trunk/README.md\n' +
+        'new file mode 10644\n' +
+        '--- /dev/null	(nonexistent)\n' +
+        '+++ b/trunk/README.md	(revision 4)\n' +
+        '@@ -0,0 +1 @@\n' +
+        '+用来测试 svndiff 和 gitdiff 的项目\n' +
+        'Index: trunk/blue_octocat.txt\n' +
+        '===================================================================\n' +
+        'diff --git a/trunk/blue_octocat.txt b/trunk/blue_octocat.txt\n' +
+        'deleted file mode 10644\n' +
+        '--- a/trunk/blue_octocat.txt	(revision 2)\n' +
+        '+++ /dev/null	(nonexistent)\n' +
+        '@@ -1 +0,0 @@\n' +
+        '-A Blue Octocat\n' +
+        'Index: trunk/octocat.txt\n' +
+        '===================================================================\n' +
+        'diff --git a/trunk/octocat.txt b/trunk/octocat.txt\n' +
+        'deleted file mode 10644\n' +
+        '--- a/trunk/octocat.txt	(revision 2)\n' +
+        '+++ /dev/null	(nonexistent)\n' +
+        '@@ -1 +0,0 @@\n' +
+        '-A Tale of Two Octocats\n' +
+        'Index: trunk/octofamily/momma_octocat.txt\n' +
+        '===================================================================\n' +
+        'diff --git a/trunk/octofamily/momma_octocat.txt b/trunk/octofamily/momma_octocat.txt\n' +
+        'deleted file mode 10644\n' +
+        '--- a/trunk/octofamily/momma_octocat.txt	(revision 2)\n' +
+        '+++ /dev/null	(nonexistent)\n' +
+        '@@ -1 +0,0 @@\n' +
+        '-A Momma Octocat\n' +
+        ' ';
+      var result = DiffParser.generateDiffJson(diff);
+      assert.equal(4, result.length);
+
+      var file1 = result[0];
+      assert.equal('trunk/README.md', file1.newName);
+      assert.equal('/dev/null', file1.oldName);
+      assert.equal(true, file1.isNew);
+      assert.equal(true, file1.isGitDiff);
+      assert.equal('10644', file1.newFileMode);
+
+      var file4 = result[3];
+      assert.equal('trunk/octofamily/momma_octocat.txt', file4.oldName);
+      assert.equal("/dev/null", file4.newName);
+      assert.equal(true, file4.isDeleted);
+      assert.equal(true, file4.isGitDiff);
+
     });
   });
 });

--- a/test/diff-parser-tests.js
+++ b/test/diff-parser-tests.js
@@ -728,5 +728,45 @@ describe('DiffParser', function() {
       assert.deepEqual(linesContent,
         [' function foo() {', '-var bar = "Whoops!";', '+var baz = "Whoops!";', ' }', ' ']);
     });
+
+    it('should parse `svn diff --git` content', function() {
+      var diff =
+        'Index: color_doc.docx\n' +
+        '===================================================================\n' +
+        'diff --git a/color_doc.docx b/color_doc.docx\n' +
+        'new file mode 10644\n' +
+        'GIT binary patch\n' +
+        'literal 296291\n' +
+        'zc%1CHV|b>|mmvJaPteH|b!;ac+w9n8$F^;E+_5|E*jC3@$F^-JoBsW0W@mS2->>`O\n' +
+        ' \n' +
+        'literal 0\n' +
+        'Hc$@<O00001\n' +
+        ' \n' +
+        'Index: color_doc.docx\n' +
+        '===================================================================\n' +
+        'diff --git a/color_doc.docx b/color_doc.docx\n' +
+        '--- a/color_doc.docx	(nonexistent)\n' +
+        '+++ b/color_doc.docx	(revision 10)\n' +
+        '\n' +
+        'Property changes on: color_doc.docx\n' +
+        '___________________________________________________________________\n' +
+        'Added: svn:executable\n' +
+        '## -0,0 +1 ##\n' +
+        '+*\n' +
+        '\\ No newline at end of property\n' +
+        'Added: svn:mime-type\n' +
+        '## -0,0 +1 ##\n' +
+        '+application/octet-stream\n' +
+        '\\ No newline at end of property\n' +
+        ' ';
+      var result = DiffParser.generateDiffJson(diff, {ignoreSvnPropertyChange: true});
+      assert.equal(1, result.length);
+
+      var file1 = result[0];
+      assert.equal('color_doc.docx', file1.oldName);
+      assert.equal('color_doc.docx', file1.newName);
+      assert.equal(true, file1.isNew);
+      assert.equal('10644', file1.newFileMode);
+    });
   });
 });


### PR DESCRIPTION
To support output of `svn diff --git`, we make three changes:

### bugfix: parse the wrong file name

`svn diff --git` will output header like this: 
```
diff --git a/color_doc.docx b/color_doc.docx
--- a/color_doc.docx	(nonexistent)
+++ b/color_doc.docx	(revision 10)
```
I parse the last part and return the right file name. ( We got `b/color_doc.docx	(revision 10)` as file name before ).

### Support 5 characters file mode

`svn diff --git` will output file mode like that:
```
new file mode 10644
```
The mode number has only 5 characters. We change to support that.

### Add new option: to auto ignore property change record

If you use `svn diff --git`, and add or delete a binary file, you will get two file change records in output. like that:

```
===================================================================
diff --git a/text.png b/text.png
deleted file mode 10644
GIT binary patch
...
===================================================================
diff --git a/text.png b/text.png
--- a/text.png  (revision 15)
+++ b/text.png  (nonexistent)

Property changes on: text.png
...
``` 
First record for "delete/new" a file. 
Second record for svn property change.
I provide a new option `ignoreSvnPropertyChange` to help you auto ignore the second record.