### PR TITLE
Fix for typescript definition file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ let dif2html = require("diff2html").Diff2Html
 
 > Pretty HTML diff
 
-    getJsonFromDiff(input: string, configuration?: Options): Result
+    getJsonFromDiff(input: string, configuration?: Options): Result[]
 
 > Intermediate Json From Git Word Diff Output
 

--- a/typescript/diff2html.d.ts
+++ b/typescript/diff2html.d.ts
@@ -55,7 +55,7 @@ declare namespace Diff2Html {
   }
 
   export interface Diff2Html {
-    getJsonFromDiff(input: string, configuration?: Options): Result;
+    getJsonFromDiff(input: string, configuration?: Options): Result[];
     getPrettyHtml(input: any, configuration?: Options): string;
   }
 }


### PR DESCRIPTION
Fixed type of return value for `Diff2Html.getJsonFromDiff`. It should be `Result[]`