### PR TITLE
fix: trim lodash dependence down to lodash.merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "diff": "^3.5.0",
     "hogan.js": "^3.0.2",
-    "lodash": "^4.17.11",
+    "lodash.merge": "^4.6.1",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@
  */
 
 (function() {
-  var merge = require('lodash/merge');
+  var merge = require('lodash.merge');
 
   function Utils() {
   }


### PR DESCRIPTION
This PR trims the npm lodash module down to use the much smaller lodash.merge module.

Fixes #186 
