### PR TITLE
Add configuration for rendering nothing if the diff shows no changes were made.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The HTML output accepts a Javascript object with configuration. Possible options
   - `maxLineLengthHighlight`: only perform diff changes highlight if lines are smaller than this, default is `10000`
   - `templates`: object with previously compiled templates to replace parts of the html
   - `rawTemplates`: object with raw not compiled templates to replace parts of the html
+  - `renderNothingWhenEmpty`: render nothing if the diff shows no change in its comparison: `true` or `false`, default is `false`
   > For more information regarding the possible templates look into [src/templates](https://github.com/rtfpessoa/diff2html/tree/master/src/templates)
 
 ** Diff2HtmlUI Helper Options **

--- a/src/diff2html.js
+++ b/src/diff2html.js
@@ -19,7 +19,8 @@
     matching: 'none',
     matchWordsThreshold: 0.25,
     matchingMaxComparisons: 2500,
-    maxLineLengthHighlight: 10000
+    maxLineLengthHighlight: 10000,
+    renderNothingWhenEmpty: false,
   };
 
   /*

--- a/src/diff2html.js
+++ b/src/diff2html.js
@@ -20,7 +20,7 @@
     matchWordsThreshold: 0.25,
     matchingMaxComparisons: 2500,
     maxLineLengthHighlight: 10000,
-    renderNothingWhenEmpty: false,
+    renderNothingWhenEmpty: false
   };
 
   /*

--- a/src/line-by-line-printer.js
+++ b/src/line-by-line-printer.js
@@ -26,6 +26,8 @@
   }
 
   LineByLinePrinter.prototype.makeFileDiffHtml = function(file, diffs) {
+    if (this.config.renderNothingWhenEmpty && file.blocks && !file.blocks.length) return '';
+
     var fileDiffTemplate = hoganUtils.template(baseTemplatesPath, 'file-diff');
     var filePathTemplate = hoganUtils.template(genericTemplatesPath, 'file-path');
     var fileIconTemplate = hoganUtils.template(iconsBaseTemplatesPath, 'file');

--- a/test/line-by-line-tests.js
+++ b/test/line-by-line-tests.js
@@ -281,6 +281,23 @@ describe('LineByLinePrinter', function() {
 
       assert.equal(expected, fileHtml);
     });
+    it('should return empty when option renderNothingWhenEmpty is true and file blocks not present', function() {
+      var lineByLinePrinter = new LineByLinePrinter({
+        renderNothingWhenEmpty: true,
+      });
+
+      var file = {
+        blocks: [],
+      };
+
+      var diffs = '<span>Random Html</span>';
+
+      var fileHtml = lineByLinePrinter.makeFileDiffHtml(file, diffs);
+
+      var expected = '';
+
+      assert.equal(expected, fileHtml);
+    });
   });
 
   describe('makeLineByLineHtmlWrapper', function() {
@@ -399,7 +416,7 @@ describe('LineByLinePrinter', function() {
         isCombined: false
       }];
 
-      var lineByLinePrinter = new LineByLinePrinter();
+      var lineByLinePrinter = new LineByLinePrinter({ renderNothingWhenEmpty: false });
       var html = lineByLinePrinter.generateLineByLineJsonHtml(exampleJson);
       var expected =
         '<div class="d2h-wrapper">\n' +

--- a/test/line-by-line-tests.js
+++ b/test/line-by-line-tests.js
@@ -283,11 +283,11 @@ describe('LineByLinePrinter', function() {
     });
     it('should return empty when option renderNothingWhenEmpty is true and file blocks not present', function() {
       var lineByLinePrinter = new LineByLinePrinter({
-        renderNothingWhenEmpty: true,
+        renderNothingWhenEmpty: true
       });
 
       var file = {
-        blocks: [],
+        blocks: []
       };
 
       var diffs = '<span>Random Html</span>';


### PR DESCRIPTION
Scenario:
A track changes style UI, where I only want to show versions of fields that have changes in the diff comparison.

Solution:
Add a new configuration object that allows the templates to return nothing when the file reports no blocks have changed.