### PR TITLE
Parser tries to replace diffLine object, not its data

### DIFF
--- a/src/diff-parser.js
+++ b/src/diff-parser.js
@@ -191,7 +191,7 @@
     }
 
     var diffLines =
-      diffInput.replace(/\\ No newline at end of file/g, '')
+      diffInput.data.replace(/\\ No newline at end of file/g, '')
         .replace(/\r\n?/g, '\n')
         .split('\n');
 


### PR DESCRIPTION
## Reproduce
I'm using webpack using npm, and building Vue.js application.
Here are instructions to see a problem.

### At webpack root directory
```bash
npm i diff2html --save # diff2html@2.7.0 installed
```

### Component.vue
```vue
<script>
var Diff2Html = require('diff2html')
export default {
  props: ['result', 'cateString', 'dateString'],
  data () {
    return {
      message: {},
      diffView: ''
    }
  },
  methods: {
    getDiff: function (diffPath) {
        this.diffView = Diff2Html.Diff2Html.getPrettyHtml(response, {
          inputFormat: 'diff',
          showFiles: true,
          matching: 'lines',
          outputFormat: 'side-by-side'
        })
      })
    }
  }
}
</script>
```

Then, chrome console shows an error msg;
```
Uncaught (in promise) TypeError: diffInput.replace is not a function
    at DiffParser.generateDiffJson (webpack-internal:///./node_modules/diff2html/src/diff-parser.js:195)
    at Diff2Html.getPrettyHtml (webpack-internal:///./node_modules/diff2html/src/diff2html.js:41)
    at eval (webpack-internal:///./node_modules/babel-loader/lib/index.js!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./src/components/Component.vue:51)
```

### Debugging
```
    var diffLines =
      diffInput.replace(/\\ No newline at end of file/g, '')
        .replace(/\r\n?/g, '\n')
        .split('\n');
```

`diffInput` is an object which has `data` property. replace() should be called in `diffInput.data`.
