### PR TITLE
Expose `oldName` and `newName` to file list templates

### DIFF
--- a/src/file-list-printer.js
+++ b/src/file-list-printer.js
@@ -29,6 +29,8 @@
 
       return lineTemplate.render({
         fileHtmlId: printerUtils.getHtmlId(file),
+        oldName: file.oldName,
+        newName: file.newName,
         fileName: printerUtils.getDiffName(file),
         deletedLines: '-' + file.deletedLines,
         addedLines: '+' + file.addedLines

--- a/test/file-list-printer-tests.js
+++ b/test/file-list-printer-tests.js
@@ -1,9 +1,53 @@
 var assert = require('assert');
-
-var fileListPrinter = new (require('../src/file-list-printer.js').FileListPrinter)();
+var FileListPrinter = require('../src/file-list-printer.js').FileListPrinter;
 
 describe('FileListPrinter', function() {
   describe('generateFileList', function() {
+    it('should expose old and new files to templates', function() {
+      var files = [{
+        addedlines: 12,
+        deletedlines: 41,
+        language: 'js',
+        oldName: 'my/file/name.js',
+        newName: 'my/file/name.js'
+      }, {
+        addedLines: 12,
+        deletedLines: 41,
+        language: 'js',
+        oldName: 'my/file/name1.js',
+        newName: 'my/file/name2.js'
+      }, {
+        addedLines: 12,
+        deletedLines: 0,
+        language: 'js',
+        oldName: 'dev/null',
+        newName: 'my/file/name.js',
+        isNew: true
+      }, {
+        addedLines: 0,
+        deletedLines: 41,
+        language: 'js',
+        oldName: 'my/file/name.js',
+        newName: 'dev/null',
+        isDeleted: true
+      }];
+
+      var fileListPrinter = new FileListPrinter({
+        rawTemplates: {
+          'file-summary-wrapper': '{{{files}}}',
+          'file-summary-line': '{{oldName}}, {{newName}}, {{fileName}}'
+        }
+      });
+
+      var fileHtml = fileListPrinter.generateFileList(files);
+      var expected = 'my/file/name.js, my/file/name.js, my/file/name.js\n' +
+        'my/file/name1.js, my/file/name2.js, my/file/{name1.js → name2.js}\n' +
+        'dev/null, my/file/name.js, my/file/name.js\n' +
+        'my/file/name.js, dev/null, my/file/name.js';
+
+      assert.equal(expected, fileHtml);
+    });
+
     it('should work for all kinds of files', function() {
       var files = [{
         addedLines: 12,
@@ -33,6 +77,7 @@ describe('FileListPrinter', function() {
         isDeleted: true
       }];
 
+      var fileListPrinter = new FileListPrinter();
       var fileHtml = fileListPrinter.generateFileList(files);
 
       var expected =


### PR DESCRIPTION
This is to address #199.

I'm not super clear on how I could implement this in a uniform way between precompiled templates and otherwise. Since hogan doesn't (seem to) support lambdas on precompiled templates, the formatted name would have to be sent down in these cases.

Without lambdas available I've simply exposed the two names to the template context, and can make a custom template with something like:
```
<span class="d2h-file-name-wrapper" data-old-name="{{oldName}}" data-new-name="{{newName}}">
```
I did not include this in the stock template as I wasn't sure it would be useful in all cases.

Any hints for how I could do this as a lambda/partial would be appreciated. Unfortunately I still think I need to post process for my intended use as I'm slicing the file names up but it would feel cleaner.