### PR TITLE
fix: remove unnesesary height property in d2h-files-diff class

### DIFF
--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -101,7 +101,6 @@
 .d2h-files-diff {
   display: block;
   width: 100%;
-  height: 100%;
 }
 
 .d2h-file-diff {


### PR DESCRIPTION
### Step 0: Describe your environment

- OS: **Pop!_OS 20.10**
- diff2html version: **3.2.0**
- Using diff2html directly or using diff2html-ui helper: **diff2html**

I am using diff2html in an electron app for developing a plugin for:
Version: Insomnia Core 2020.5.2
Release date: 12/9/2020
OS: Linux x64 5.8.0-7642-generic
Electron: 9.1.1
Node: 12.14.1
V8: 8.3.110.13-electron.0
Architecture: x64
node-libcurl: libcurl/7.69.1 OpenSSL/1.1.1g zlib/1.2.11 brotli/1.0.9 libidn2/2.3.0 libssh2/1.9.0 nghttp2/1.41.0

### Step 1: Describe the problem:

#### Steps to reproduce:

I am using functions from readmes and output in an HTML wrapper without any styling.

```javascript
const diffJson = Diff2html.parse(diff);
const diffHtml = Diff2html.html(diffJson, {
  drawFileList: true,
  outputFormat: "side-by-side",
});
```
But if I use outputFormat: "side-by-side" the whole viewport is used for each file diff.


#### Observed Results:
This is rendered HTML:

![Peek 2021-02-07 02-59](https://user-images.githubusercontent.com/510560/107132963-cd439780-68f4-11eb-9814-9df44651f023.gif)

#### Expected Results:

I would expect them to be rendered without unnecessary space between files
![Screenshot from 2021-02-07 03-06-35](https://user-images.githubusercontent.com/510560/107132960-c7e64d00-68f4-11eb-9c94-98923c3dd3cd.png)


#### Relevant Code:

```css
.d2h-files-diff {
  display: block;
  width: 100%;
  height: 100%; /* this is unnecessary */
}
```

