### PR TITLE
fix: only display "Viewed" checkbox if `fileContentToggle` is set

### DIFF
--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -74,7 +74,7 @@
 
 .d2h-file-collapse {
   justify-content: flex-end;
-  display: flex;
+  display: none;
   cursor: pointer;
   font-size: 12px;
   align-items: center;

--- a/src/ui/js/diff2html-ui-base.ts
+++ b/src/ui/js/diff2html-ui-base.ts
@@ -112,7 +112,9 @@ export class Diff2HtmlUI {
   }
 
   fileContentToggle(): void {
-    this.targetElement.querySelectorAll('.d2h-file-collapse').forEach(fileContentToggleBtn => {
+    this.targetElement.querySelectorAll<HTMLElement>('.d2h-file-collapse').forEach(fileContentToggleBtn => {
+      fileContentToggleBtn.style.display = 'flex';
+
       const toggleFileContents: (selector: string) => void = selector => {
         const fileContents: HTMLElement | null | undefined = fileContentToggleBtn
           .closest('.d2h-file-wrapper')


### PR DESCRIPTION
Currently the "Viewed" checkbox introduced in #358 is displayed even if `fileContentToggle` is not set or `false`. This PR fixes this behavior so that the checkbox is only displayed if `fileContentToggle` is `true`.

As a result, also fixes #364.