### PR TITLE
feature: `diffMaxLineLength` to mark file diff as too big depending on diff line length

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,10 @@ The HTML output accepts a Javascript object with configuration. Possible options
 - `diffStyle`: show differences level in each line: `word` or `char`, default is `word`
 - `diffMaxChanges`: number of changed lines after which a file diff is deemed as too big and not displayed, default is
   `undefined`
-- `diffTooBigMessage`: function allowing to customize the message in case of file diff too big (if `diffMaxChanges` is
-  set)
+- `diffMaxLineLength`: number of characters in a diff line after which a file diff is deemed as too big and not
+  displayed, default is `undefined`
+- `diffTooBigMessage`: function allowing to customize the message in case of file diff too big (if `diffMaxChanges` or
+  `diffMaxLineLength` is set)
 - `matching`: matching level: `'lines'` for matching lines, `'words'` for matching lines and words or `'none'`, default
   is `none`
 - `matchWordsThreshold`: similarity threshold for word matching, default is `0.25`

--- a/src/__tests__/diff-parser-tests.ts
+++ b/src/__tests__/diff-parser-tests.ts
@@ -2201,5 +2201,231 @@ describe('DiffParser', () => {
         ]
       `);
     });
+
+    it('should work when `diffMaxLineLength` is set and excedeed', () => {
+      const diff =
+        'diff --git a/src/core/init.js b/src/core/init.js\n' +
+        'index e49196a..50f310c 100644\n' +
+        '--- a/src/core/init.js\n' +
+        '+++ b/src/core/init.js\n' +
+        '@@ -101,7 +101,7 @@ var rootjQuery,\n' +
+        '     // HANDLE: $(function)\n' +
+        '     // Shortcut for document ready\n' +
+        '     } else if ( jQuery.isFunction( selector ) ) {\n' +
+        '-      return typeof rootjQuery.ready !== "undefined" ?\n' +
+        '+      return rootjQuery.ready !== undefined ?\n' +
+        '         rootjQuery.ready( selector ) :\n' +
+        '         // Execute immediately if ready is not present\n' +
+        '         selector( jQuery );\n' +
+        'diff --git a/src/event.js b/src/event.js\n' +
+        'index 7336f4d..6183f70 100644\n' +
+        '--- a/src/event.js\n' +
+        '+++ b/src/event.js\n' +
+        '@@ -1,6 +1,5 @@\n' +
+        ' define([\n' +
+        '   "./core",\n' +
+        '-  "./var/strundefined",\n' +
+        '   "./var/rnotwhite",\n' +
+        '   "./var/hasOwn",\n' +
+        '   "./var/slice",\n';
+      const result = parse(diff, { diffMaxLineLength: 50 });
+      expect(result).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "addedLines": 0,
+            "blocks": Array [
+              Object {
+                "header": "Diff too big to be displayed",
+                "lines": Array [],
+                "newStartLine": 0,
+                "oldStartLine": 0,
+                "oldStartLine2": null,
+              },
+            ],
+            "checksumAfter": "50f310c",
+            "checksumBefore": "e49196a",
+            "deletedLines": 0,
+            "isCombined": false,
+            "isGitDiff": true,
+            "isTooBig": true,
+            "language": "js",
+            "mode": "100644",
+            "newName": "src/core/init.js",
+            "oldName": "src/core/init.js",
+          },
+          Object {
+            "addedLines": 0,
+            "blocks": Array [
+              Object {
+                "header": "@@ -1,6 +1,5 @@",
+                "lines": Array [
+                  Object {
+                    "content": " define([",
+                    "newNumber": 1,
+                    "oldNumber": 1,
+                    "type": "context",
+                  },
+                  Object {
+                    "content": "   \\"./core\\",",
+                    "newNumber": 2,
+                    "oldNumber": 2,
+                    "type": "context",
+                  },
+                  Object {
+                    "content": "-  \\"./var/strundefined\\",",
+                    "newNumber": undefined,
+                    "oldNumber": 3,
+                    "type": "delete",
+                  },
+                  Object {
+                    "content": "   \\"./var/rnotwhite\\",",
+                    "newNumber": 3,
+                    "oldNumber": 4,
+                    "type": "context",
+                  },
+                  Object {
+                    "content": "   \\"./var/hasOwn\\",",
+                    "newNumber": 4,
+                    "oldNumber": 5,
+                    "type": "context",
+                  },
+                  Object {
+                    "content": "   \\"./var/slice\\",",
+                    "newNumber": 5,
+                    "oldNumber": 6,
+                    "type": "context",
+                  },
+                ],
+                "newStartLine": 1,
+                "oldStartLine": 1,
+                "oldStartLine2": null,
+              },
+            ],
+            "checksumAfter": "6183f70",
+            "checksumBefore": "7336f4d",
+            "deletedLines": 1,
+            "isCombined": false,
+            "isGitDiff": true,
+            "language": "js",
+            "mode": "100644",
+            "newName": "src/event.js",
+            "oldName": "src/event.js",
+          },
+        ]
+      `);
+    });
+
+    it('should work when `diffMaxLineLength` is set and excedeed, and `diffTooBigMessage` is set', () => {
+      const diff =
+        'diff --git a/src/core/init.js b/src/core/init.js\n' +
+        'index e49196a..50f310c 100644\n' +
+        '--- a/src/core/init.js\n' +
+        '+++ b/src/core/init.js\n' +
+        '@@ -101,7 +101,7 @@ var rootjQuery,\n' +
+        '     // HANDLE: $(function)\n' +
+        '     // Shortcut for document ready\n' +
+        '     } else if ( jQuery.isFunction( selector ) ) {\n' +
+        '-      return typeof rootjQuery.ready !== "undefined" ?\n' +
+        '+      return rootjQuery.ready !== undefined ?\n' +
+        '         rootjQuery.ready( selector ) :\n' +
+        '         // Execute immediately if ready is not present\n' +
+        '         selector( jQuery );\n' +
+        'diff --git a/src/event.js b/src/event.js\n' +
+        'index 7336f4d..6183f70 100644\n' +
+        '--- a/src/event.js\n' +
+        '+++ b/src/event.js\n' +
+        '@@ -1,6 +1,5 @@\n' +
+        ' define([\n' +
+        '   "./core",\n' +
+        '-  "./var/strundefined",\n' +
+        '   "./var/rnotwhite",\n' +
+        '   "./var/hasOwn",\n' +
+        '   "./var/slice",\n';
+      const result = parse(diff, { diffMaxLineLength: 50, diffTooBigMessage: (i: number) => `Custom ${i}` });
+      expect(result).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "addedLines": 0,
+            "blocks": Array [
+              Object {
+                "header": "Custom 0",
+                "lines": Array [],
+                "newStartLine": 0,
+                "oldStartLine": 0,
+                "oldStartLine2": null,
+              },
+            ],
+            "checksumAfter": "50f310c",
+            "checksumBefore": "e49196a",
+            "deletedLines": 0,
+            "isCombined": false,
+            "isGitDiff": true,
+            "isTooBig": true,
+            "language": "js",
+            "mode": "100644",
+            "newName": "src/core/init.js",
+            "oldName": "src/core/init.js",
+          },
+          Object {
+            "addedLines": 0,
+            "blocks": Array [
+              Object {
+                "header": "@@ -1,6 +1,5 @@",
+                "lines": Array [
+                  Object {
+                    "content": " define([",
+                    "newNumber": 1,
+                    "oldNumber": 1,
+                    "type": "context",
+                  },
+                  Object {
+                    "content": "   \\"./core\\",",
+                    "newNumber": 2,
+                    "oldNumber": 2,
+                    "type": "context",
+                  },
+                  Object {
+                    "content": "-  \\"./var/strundefined\\",",
+                    "newNumber": undefined,
+                    "oldNumber": 3,
+                    "type": "delete",
+                  },
+                  Object {
+                    "content": "   \\"./var/rnotwhite\\",",
+                    "newNumber": 3,
+                    "oldNumber": 4,
+                    "type": "context",
+                  },
+                  Object {
+                    "content": "   \\"./var/hasOwn\\",",
+                    "newNumber": 4,
+                    "oldNumber": 5,
+                    "type": "context",
+                  },
+                  Object {
+                    "content": "   \\"./var/slice\\",",
+                    "newNumber": 5,
+                    "oldNumber": 6,
+                    "type": "context",
+                  },
+                ],
+                "newStartLine": 1,
+                "oldStartLine": 1,
+                "oldStartLine2": null,
+              },
+            ],
+            "checksumAfter": "6183f70",
+            "checksumBefore": "7336f4d",
+            "deletedLines": 1,
+            "isCombined": false,
+            "isGitDiff": true,
+            "language": "js",
+            "mode": "100644",
+            "newName": "src/event.js",
+            "oldName": "src/event.js",
+          },
+        ]
+      `);
+    });
   });
 });

--- a/src/diff-parser.ts
+++ b/src/diff-parser.ts
@@ -5,6 +5,7 @@ export interface DiffParserConfig {
   srcPrefix?: string;
   dstPrefix?: string;
   diffMaxChanges?: number;
+  diffMaxLineLength?: number;
   diffTooBigMessage?: (fileIndex: number) => string;
 }
 
@@ -303,6 +304,21 @@ export function parse(diffInput: string, config: DiffParserConfig = {}): DiffFil
 
     // Ignore remaining diff for current file if marked as too big
     if (currentFile?.isTooBig) {
+      return;
+    }
+
+    if (currentFile && typeof config.diffMaxLineLength === 'number' && line.length > config.diffMaxLineLength) {
+      currentFile.isTooBig = true;
+      currentFile.addedLines = 0;
+      currentFile.deletedLines = 0;
+      currentFile.blocks = [];
+      currentBlock = null;
+
+      const message =
+        typeof config.diffTooBigMessage === 'function'
+          ? config.diffTooBigMessage(files.length)
+          : 'Diff too big to be displayed';
+      startBlock(message);
       return;
     }
 

--- a/src/diff-parser.ts
+++ b/src/diff-parser.ts
@@ -307,25 +307,11 @@ export function parse(diffInput: string, config: DiffParserConfig = {}): DiffFil
       return;
     }
 
-    if (currentFile && typeof config.diffMaxLineLength === 'number' && line.length > config.diffMaxLineLength) {
-      currentFile.isTooBig = true;
-      currentFile.addedLines = 0;
-      currentFile.deletedLines = 0;
-      currentFile.blocks = [];
-      currentBlock = null;
-
-      const message =
-        typeof config.diffTooBigMessage === 'function'
-          ? config.diffTooBigMessage(files.length)
-          : 'Diff too big to be displayed';
-      startBlock(message);
-      return;
-    }
-
     if (
       currentFile &&
-      typeof config.diffMaxChanges === 'number' &&
-      currentFile.addedLines + currentFile.deletedLines > config.diffMaxChanges
+      ((typeof config.diffMaxChanges === 'number' &&
+        currentFile.addedLines + currentFile.deletedLines > config.diffMaxChanges) ||
+        (typeof config.diffMaxLineLength === 'number' && line.length > config.diffMaxLineLength))
     ) {
       currentFile.isTooBig = true;
       currentFile.addedLines = 0;


### PR DESCRIPTION
Similar to `diffMaxChanges`, this PR introduces a new `diffMaxLineLength` option which allows defining a diff line length threshold above which file diff parsing is stopped and the diff is marked as too big.

This is particularly useful for diff containing big one-line files (> 1MB for instance): see https://huggingface.co/kssteven/ibert-roberta-large-mnli/commit/281cc09b0dd3faa7cd11502a6bac0aeb3c311f0f for an example (last file of the diff - beware, this will probably make your browser crash!)