### PR TITLE
fix: Calling "getLanguage" manually causes highlighting to fail

### DIFF
--- a/src/ui/js/diff2html-ui-base.ts
+++ b/src/ui/js/diff2html-ui-base.ts
@@ -142,7 +142,6 @@ export class Diff2HtmlUI {
       // HACK: help Typescript know that `this.hljs` is defined since we already checked it
       if (this.hljs === null) return;
       const language = file.getAttribute('data-lang');
-      const hljsLanguage = language ? this.hljs.getLanguage(language) : undefined;
 
       // Collect all the code lines and execute the highlight on them
       const codeLines = file.querySelectorAll('.d2h-code-line-ctn');
@@ -157,7 +156,7 @@ export class Diff2HtmlUI {
 
         const result: HighlightResult = closeTags(
           this.hljs.highlight(text, {
-            language: hljsLanguage?.name || 'plaintext',
+            language: language || 'plaintext',
             ignoreIllegals: true,
           }),
         );


### PR DESCRIPTION
In `Diff2HtmlUI.highlightCode()`, using `getLanguage().name` as the parameter of `hljs.highlight()` will cause highlighting to throw an exception and fail.

![1BF6474B4E755B0253261FBF8984C7BB](https://user-images.githubusercontent.com/21163191/128618980-e622dd7c-a944-49e7-bcc5-e0126884be92.png)


For example, if you execute `getLanguage('xml').name` on an XML-like file, you will get `HTML, XML`. In `hljs.highlight()`, the value will be `getLanguage()` again, this time an exception of `Unknown language: "HTML, XML"` will be thrown, because the type related to `HTML, XML` could not be found

![114121B0D816BE81BA18C9077EE0B7A7](https://user-images.githubusercontent.com/21163191/128618512-d229ea73-7003-4c34-91bf-6684010c5084.png)
![5C495D33DB340F04AED8C0E5F1599EB2](https://user-images.githubusercontent.com/21163191/128618519-36599f3b-aeba-4aeb-85c3-5f810a3e3ec5.jpg)
