### PR TITLE
Lazy loading files support

### DIFF
--- a/src/diff2html.ts
+++ b/src/diff2html.ts
@@ -12,6 +12,7 @@ export interface Diff2HtmlConfig
     HoganJsUtilsConfig {
   outputFormat?: OutputFormatType;
   drawFileList?: boolean;
+  lazy?: boolean;
 }
 
 export const defaultDiff2HtmlConfig = {
@@ -19,6 +20,7 @@ export const defaultDiff2HtmlConfig = {
   ...defaultSideBySideRendererConfig,
   outputFormat: OutputFormatType.LINE_BY_LINE,
   drawFileList: true,
+  lazy: false,
 };
 
 export function parse(diffInput: string, configuration: Diff2HtmlConfig = {}): DiffFile[] {
@@ -36,8 +38,18 @@ export function html(diffInput: string | DiffFile[], configuration: Diff2HtmlCon
 
   const diffOutput =
     config.outputFormat === 'side-by-side'
-      ? new SideBySideRenderer(hoganUtils, config).render(diffJson)
-      : new LineByLineRenderer(hoganUtils, config).render(diffJson);
+      ? new SideBySideRenderer(hoganUtils, config).render(config.lazy ? [] : diffJson)
+      : new LineByLineRenderer(hoganUtils, config).render(config.lazy ? [] : diffJson);
 
   return fileList + diffOutput;
+}
+
+export function htmlFile(diffFile: DiffFile, configuration: Diff2HtmlConfig = {}): string {
+  const config = { ...defaultDiff2HtmlConfig, ...configuration };
+
+  const hoganUtils = new HoganJsUtils(config);
+
+  return config.outputFormat === 'side-by-side'
+      ? new SideBySideRenderer(hoganUtils, config).renderFile(diffFile)
+      : new LineByLineRenderer(hoganUtils, config).renderFile(diffFile);
 }

--- a/src/line-by-line-renderer.ts
+++ b/src/line-by-line-renderer.ts
@@ -55,6 +55,11 @@ export default class LineByLineRenderer {
     return this.hoganUtils.render(genericTemplatesPath, 'wrapper', { content: diffsHtml });
   }
 
+  renderFile(diffFile: DiffFile): string {
+    const diffs = diffFile.blocks.length ? this.generateFileHtml(diffFile) : this.generateEmptyDiff();
+    return this.makeFileDiffHtml(diffFile, diffs);
+  }
+
   makeFileDiffHtml(file: DiffFile, diffs: string): string {
     if (this.config.renderNothingWhenEmpty && Array.isArray(file.blocks) && file.blocks.length === 0) return '';
 

--- a/src/side-by-side-renderer.ts
+++ b/src/side-by-side-renderer.ts
@@ -40,19 +40,14 @@ export default class SideBySideRenderer {
   }
 
   render(diffFiles: DiffFile[]): string {
-    const diffsHtml = diffFiles
-      .map(file => {
-        let diffs;
-        if (file.blocks.length) {
-          diffs = this.generateFileHtml(file);
-        } else {
-          diffs = this.generateEmptyDiff();
-        }
-        return this.makeFileDiffHtml(file, diffs);
-      })
-      .join('\n');
+    const diffsHtml = diffFiles.map(this.renderFile).join('\n');
 
     return this.hoganUtils.render(genericTemplatesPath, 'wrapper', { content: diffsHtml });
+  }
+
+  renderFile(diffFile: DiffFile): string {
+    const diffs = diffFile.blocks.length ? this.generateFileHtml(diffFile) : this.generateEmptyDiff();
+    return this.makeFileDiffHtml(diffFile, diffs);
   }
 
   makeFileDiffHtml(file: DiffFile, diffs: FileHtml): string {


### PR DESCRIPTION
Fixes #405 

* Adds `lazy` option that will make initial render to only have the file list and no contents
* Allows to click file names and this will render contents.

**Current Problems**
* ~~No highlight~~
* Files are rendered in the order they are clicked which means the list before the contents will not have the same order as the rendered files.