### PR TITLE
Fix indentation in Diff2HtmlUI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,12 +269,12 @@ document.addEventListener('DOMContentLoaded', () => {
   </head>
   <script>
     const diffString = `diff --git a/sample.js b/sample.js
-      index 0000001..0ddf2ba
-      --- a/sample.js
-      +++ b/sample.js
-      @@ -1 +1 @@
-      -console.log("Hello World!")
-      +console.log("Hello from Diff2Html!")`;
+index 0000001..0ddf2ba
+--- a/sample.js
++++ b/sample.js
+@@ -1 +1 @@
+-console.log("Hello World!")
++console.log("Hello from Diff2Html!")`;
 
     document.addEventListener('DOMContentLoaded', function () {
       var targetElement = document.getElementById('myDiffElement');


### PR DESCRIPTION
On Chrome 94, I could only get this example to work by fixing the indentation in `diffString`. I attached a before & after screenshot.

<img width="1219" alt="CleanShot 2021-10-20 at 15 53 36@2x" src="https://user-images.githubusercontent.com/14110/138183571-2a6a6e43-34e5-42d9-af1a-74989e30b004.png">
