### PR TITLE
Fix broken link to documentation

### DIFF
--- a/website/templates/pages/index/content.handlebars
+++ b/website/templates/pages/index/content.handlebars
@@ -85,8 +85,8 @@
             <div class="column">
                 <h4 class="title is-size-4 is-spaced"><strong>With command line integration</strong></h4>
                 <p>We work hard to make sure you can have your diffs in a simple and flexible
-                    way. Go here for the <a href="https://github.com/rtfpessoa/diff2html-cli" target="_blank"
-                        rel="noopener" rel="noreferrer"></a>full
+                    way. Go here for the <a href="https://github.com/rtfpessoa/diff2html-cli#readme" target="_blank"
+                        rel="noopener" rel="noreferrer">full
                     documentation</a>.
                 </p>
             </div>


### PR DESCRIPTION
Fixes duplicate closing tag (which made the link not usable at all) and linked readme section to jump directly to docs