### PR TITLE
Add Robusta to list of projects using diff2html

### DIFF
--- a/website/templates/pages/index/content.handlebars
+++ b/website/templates/pages/index/content.handlebars
@@ -466,6 +466,21 @@
                     </footer>
                 </div>
             </div>
+            
+            <div class="column is-one-quarter-widescreen is-flex">
+                <div class="box is-flex is-fullwidth is-vertical">
+                    <header>
+                        <p class="is-size-5 has-text-weight-bold">Robusta</p>
+                    </header>
+                    <section class="media-content">
+                        <p>Open source Kubernetes troubleshooting and automation platform</p>
+                    </section>
+                    <footer>
+                        <a href="https://docs.robusta.dev/master/" target="_blank" rel="noopener"
+                            rel="noreferrer">Website</a>
+                    </footer>
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
This adds https://github.com/robusta-dev/robusta to the list of projects using diff2html.

We use diff2html and love it :)