### PR TITLE
add ignore white spaces to side by side view

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ The HTML output accepts a Javascript object with configuration. Possible options
   `false`
 - `matchingMaxComparisons`: perform at most this much comparisons for line matching a block of changes, default is
   `2500`
+- `ignoreWhiteSpaces`: ignore line with only repeated white spacings (Only in Side by side View).
 - `maxLineSizeInBlockForComparison`: maximum number os characters of the bigger line in a block to apply comparison,
   default is `200`
 - `compiledTemplates`: object ([Hogan.js](https://github.com/twitter/hogan.js/) template values) with previously

--- a/README.md
+++ b/README.md
@@ -376,7 +376,8 @@ The HTML output accepts a Javascript object with configuration. Possible options
   `false`
 - `matchingMaxComparisons`: perform at most this much comparisons for line matching a block of changes, default is
   `2500`
-- `ignoreWhiteSpaces`: ignore line with only repeated white spacings (Only in Side by side View).
+- `ignoreWhiteSpaces`: ignore line with only repeated white spacings (Only in Side by side View), using recommended
+  matching type with this option is "words".
 - `maxLineSizeInBlockForComparison`: maximum number os characters of the bigger line in a block to apply comparison,
   default is `200`
 - `compiledTemplates`: object ([Hogan.js](https://github.com/twitter/hogan.js/) template values) with previously

--- a/src/render-utils.ts
+++ b/src/render-utils.ts
@@ -37,6 +37,7 @@ export interface RenderConfig {
   matchWordsThreshold?: number;
   maxLineLengthHighlight?: number;
   diffStyle?: DiffStyleType;
+  ignoreWhiteSpaces?: boolean;
 }
 
 export const defaultRenderConfig = {
@@ -44,6 +45,7 @@ export const defaultRenderConfig = {
   matchWordsThreshold: 0.25,
   maxLineLengthHighlight: 10000,
   diffStyle: DiffStyleType.WORD,
+  ignoreWhiteSpaces: false,
 };
 
 const separator = '/';

--- a/src/side-by-side-renderer.ts
+++ b/src/side-by-side-renderer.ts
@@ -100,41 +100,34 @@ export default class SideBySideRenderer {
           left: this.makeHeaderHtml(block.header, file),
           right: this.makeHeaderHtml(''),
         };
-        let contextStash: (DiffLineContent & DiffLineContext)[] = []; // if white space are ignored, context  should be relevant
-        let processContext = false;
+
         this.applyLineGroupping(block).forEach(([contextLines, oldLines, newLines]) => {
           if (oldLines.length && newLines.length && !contextLines.length) {
             this.applyRematchMatching(oldLines, newLines, matcher).map(([oldLines, newLines]) => {
               const { left, right } = this.processChangedLines(file.isCombined, oldLines, newLines);
               fileHtml.left += left;
               fileHtml.right += right;
-              if (!left && !right) {
-                contextStash = [];
-                processContext = false;
-              } else processContext = true;
             });
-          } else if (contextLines.length || contextStash.length) {
-            if (!processContext) contextStash = contextStash.concat(contextLines);
-            else
-              contextLines.concat(processContext ? contextStash : []).forEach(line => {
-                const { prefix, content } = renderUtils.deconstructLine(line.content, file.isCombined);
-                const { left, right } = this.generateLineHtml(
-                  {
-                    type: renderUtils.CSSLineClass.CONTEXT,
-                    prefix: prefix,
-                    content: content,
-                    number: line.oldNumber,
-                  },
-                  {
-                    type: renderUtils.CSSLineClass.CONTEXT,
-                    prefix: prefix,
-                    content: content,
-                    number: line.newNumber,
-                  },
-                );
-                fileHtml.left += left;
-                fileHtml.right += right;
-              });
+          } else if (contextLines.length) {
+            contextLines.forEach(line => {
+              const { prefix, content } = renderUtils.deconstructLine(line.content, file.isCombined);
+              const { left, right } = this.generateLineHtml(
+                {
+                  type: renderUtils.CSSLineClass.CONTEXT,
+                  prefix: prefix,
+                  content: content,
+                  number: line.oldNumber,
+                },
+                {
+                  type: renderUtils.CSSLineClass.CONTEXT,
+                  prefix: prefix,
+                  content: content,
+                  number: line.newNumber,
+                },
+              );
+              fileHtml.left += left;
+              fileHtml.right += right;
+            });
           } else if (oldLines.length || newLines.length) {
             const { left, right } = this.processChangedLines(file.isCombined, oldLines, newLines);
             fileHtml.left += left;

--- a/website/templates/pages/demo/content.handlebars
+++ b/website/templates/pages/demo/content.handlebars
@@ -50,6 +50,12 @@
         </label>
       </div>
       <div class="column is-one-fifth-widescreen">
+        <label title="Show/Hide white spaces (only in side-by-side view)">
+          <p>Ignore white spaces(side-by-side only)</p>
+          <input class="options-label-value" id="diff-url-options-ignore-w-spaces" type="checkbox" name="drawFileList"/>
+        </label>
+      </div>
+      <div class="column is-one-fifth-widescreen">
         <label title="Level of matching for the comparison algorithm">
           <p>Matching Type</p>
           <select class="options-label-value" id="diff-url-options-matching" name="matching">

--- a/website/templates/pages/demo/demo.ts
+++ b/website/templates/pages/demo/demo.ts
@@ -206,6 +206,7 @@ type Elements = {
   };
   checkboxes: {
     drawFileList: HTMLInputElement;
+    ignoreWhiteSpaces: HTMLInputElement;
   };
 };
 
@@ -265,6 +266,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     },
     checkboxes: {
       drawFileList: getHTMLInputElementById('diff-url-options-show-files'),
+      ignoreWhiteSpaces: getHTMLInputElementById('diff-url-options-ignore-w-spaces'),
     },
   };
 
@@ -277,6 +279,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   config.matchWordsThreshold && (elements.options.wordsThreshold.value = config.matchWordsThreshold.toString());
   config.matchingMaxComparisons &&
     (elements.options.matchingMaxComparisons.value = config.matchingMaxComparisons.toString());
+  config.ignoreWhiteSpaces && (elements.checkboxes.ignoreWhiteSpaces.checked = config.ignoreWhiteSpaces);
 
   Object.entries(elements.options).forEach(([option, element]) =>
     element.addEventListener('change', () => {


### PR DESCRIPTION
This is to add the functionality of ignoring white spaces, I added only to side by side view for demonstration purpose, the concept is to skip a line that has repeated space and both before and after changes takes place in same line.

To pass the all the unit tests I added reverted a commit that skips some context line when white spaces are ignored, as it makes the overall document more relevant (c1d670169950c2f8d71a8f691f7314263e2cc3b9). but I really think it makes sense to skip these context lines.