### PR TITLE
Set display:flex to align inline-block elements

### DIFF
--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -99,6 +99,7 @@
 }
 
 .d2h-files-diff {
+  display: flex;
   width: 100%;
 }
 


### PR DESCRIPTION
(Sorry if the translation is unnatural as I am using DeepL to translate)

I noticed that under certain conditions, Inline-Block elements may be misaligned.
I think this often happens when a large Diff is displayed SideBySide, but I am not sure of the condition.

To fix this, I set display: flex on the parent element of the Inline-Block element.

This issue is also noted in the following Issue.
https://github.com/rtfpessoa/diff2html-cli/issues/138