### PR TITLE
Make d2h-d-none override visibility: fix broken hiding of viewed files

### DIFF
--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -6,7 +6,7 @@
  */
 
 .d2h-d-none {
-  display: none;
+  display: none !important;
 }
 
 .d2h-wrapper {


### PR DESCRIPTION
Fixes a regression: toggling Viewed no longer hides the patch for the file.

#### Steps to reproduce:

1. *** show a diff (e.g. at https://jsbin.com/salayecelu/edit?html,output )
2. *** click "Viewed"
3. *** observe that the file is still shown

#### Expected Results:

The file should hide when "Viewed" is toggled on.

I believe the problem was introduced in b164b511d80edf25ca942b50dc4911b12257b7ee 

Since `.d2h-d-none` is the first rule in the file, other rules with the same specificity override it, e.g. line 102 in `.d2h-files-diff`. This means hiding no longer works. This commit fixes that; alternatively, the `.d2h-d-none` rule should be moved to the end of the file if you don't like `!important`.