### PR TITLE
Fix file collapse UI regression

### DIFF
--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -103,7 +103,8 @@
   overflow-y: hidden;
 }
 
-.d2h-files-diff.d2h-d-none, .d2h-file-diff.d2h-d-none {
+.d2h-files-diff.d2h-d-none,
+.d2h-file-diff.d2h-d-none {
   display: none;
 }
 

--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -5,10 +5,6 @@
  *
  */
 
-.d2h-d-none {
-  display: none;
-}
-
 .d2h-wrapper {
   text-align: left;
 }
@@ -105,6 +101,10 @@
 
 .d2h-file-diff {
   overflow-y: hidden;
+}
+
+.d2h-files-diff.d2h-d-none, .d2h-file-diff.d2h-d-none {
+  display: none;
 }
 
 .d2h-file-side-diff {


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/rtfpessoa/diff2html/commit/b164b511d80edf25ca942b50dc4911b12257b7ee where toggling the **Viewed** checkbox ceased hiding the file diff. Improves upon #445's implementation by increasing the specificity of the `.d2h-d-none` selector rather than using `!important`.

## Steps to reproduce
1. Show a diff (see [this live demo](https://jsbin.com/salayecelu/edit?html,output)).
2. Click "Viewed".
3. Observe that the file is still shown.

Note: this regression is not present in the [diff2html demo](https://diff2html.xyz/demo.html) as it's probably using an older version of the library.

## Expected Results
The file should hide when "Viewed" is toggled on.