### PR TITLE
Implement support for sticky file headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ draw(): void
 synchronisedScroll(): void
 fileListToggle(startVisible: boolean): void
 highlightCode(): void
-stickyFileHeader(): void
+stickyFileHeaders(): void
 ```
 
 ### Diff2HtmlUI Configuration
@@ -166,7 +166,7 @@ stickyFileHeader(): void
 - `fileListToggle`: allow the file summary list to be toggled: `true` or `false`, default is `true`
 - `fileListStartVisible`: choose if the file summary list starts visible: `true` or `false`, default is `false`
 - `fileContentToggle`: allow each file contents to be toggled: `true` or `false`, default is `true`
-- `stickyFileHeader`: make file headers sticky: `true` or `false`, default is `false`
+- `stickyFileHeaders`: make file headers sticky: `true` or `false`, default is `true`
 - [All the options](#diff2html-configuration) from Diff2Html are also valid configurations in Diff2HtmlUI
 
 ### Diff2HtmlUI Browser

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ draw(): void
 synchronisedScroll(): void
 fileListToggle(startVisible: boolean): void
 highlightCode(): void
+stickyFileHeader(): void
 ```
 
 ### Diff2HtmlUI Configuration
@@ -165,6 +166,7 @@ highlightCode(): void
 - `fileListToggle`: allow the file summary list to be toggled: `true` or `false`, default is `true`
 - `fileListStartVisible`: choose if the file summary list starts visible: `true` or `false`, default is `false`
 - `fileContentToggle`: allow each file contents to be toggled: `true` or `false`, default is `true`
+- `stickyFileHeader`: make file headers sticky: `true` or `false`, default is `false`
 - [All the options](#diff2html-configuration) from Diff2Html are also valid configurations in Diff2HtmlUI
 
 ### Diff2HtmlUI Browser

--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -17,6 +17,11 @@
   background-color: #f7f7f7;
   font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
+.d2h-file-header.d2h-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
 
 .d2h-file-stats {
   display: -webkit-box;

--- a/src/ui/js/diff2html-ui-base.ts
+++ b/src/ui/js/diff2html-ui-base.ts
@@ -16,6 +16,7 @@ export interface Diff2HtmlUIConfig extends Diff2HtmlConfig {
    */
   smartSelection?: boolean;
   fileContentToggle?: boolean;
+  stickyFileHeaders?: boolean;
 }
 
 export const defaultDiff2HtmlUIConfig = {
@@ -31,6 +32,7 @@ export const defaultDiff2HtmlUIConfig = {
    */
   smartSelection: true,
   fileContentToggle: true,
+  stickyFileHeaders: false,
 };
 
 export class Diff2HtmlUI {
@@ -54,6 +56,7 @@ export class Diff2HtmlUI {
     if (this.config.highlight) this.highlightCode();
     if (this.config.fileListToggle) this.fileListToggle(this.config.fileListStartVisible);
     if (this.config.fileContentToggle) this.fileContentToggle();
+    if (this.config.stickyFileHeaders) this.stickyFileHeaders();
   }
 
   synchronisedScroll(): void {
@@ -185,6 +188,12 @@ export class Diff2HtmlUI {
         }
         line.innerHTML = result.value;
       });
+    });
+  }
+
+  stickyFileHeaders(): void {
+    this.targetElement.querySelectorAll('.d2h-file-header').forEach(header => {
+      header.classList.add('d2h-sticky-header');
     });
   }
 

--- a/src/ui/js/diff2html-ui-base.ts
+++ b/src/ui/js/diff2html-ui-base.ts
@@ -32,7 +32,7 @@ export const defaultDiff2HtmlUIConfig = {
    */
   smartSelection: true,
   fileContentToggle: true,
-  stickyFileHeaders: false,
+  stickyFileHeaders: true,
 };
 
 export class Diff2HtmlUI {


### PR DESCRIPTION
Closes #455 

Adds support for sticky file headers through an optional CSS class and an option on `Diff2HtmlUI`. By default, sticky file headers are not enabled (I'm happy to change this based on feedback). I documented this new option in the README. I did not add tests as I did not spot a test suite for `Diff2HtmlUI`, please let me know if (and where) I should add some tests :slightly_smiling_face: 

Further details can be found in 7d4a5dce6f5e17c6ae2d09f62d503178bfe81d3f