### PR TITLE
feat: hand in file/line to generic line template

### DIFF
--- a/src/__tests__/line-by-line-tests.ts
+++ b/src/__tests__/line-by-line-tests.ts
@@ -23,9 +23,19 @@ describe('LineByLineRenderer', () => {
 
   describe('makeLineHtml', () => {
     it('should work for insertions', () => {
+      const file = {
+        addedLines: 12,
+        deletedLines: 41,
+        language: 'js',
+        oldName: 'my/file/name.js',
+        newName: 'my/file/name.js',
+        isCombined: false,
+        isGitDiff: false,
+        blocks: [],
+      };
       const hoganUtils = new HoganJsUtils({});
       const lineByLineRenderer = new LineByLineRenderer(hoganUtils, {});
-      const fileHtml = lineByLineRenderer.generateSingleLineHtml({
+      const fileHtml = lineByLineRenderer.generateSingleLineHtml(file, {
         type: CSSLineClass.INSERTS,
         prefix: '+',
         content: 'test',
@@ -49,9 +59,19 @@ describe('LineByLineRenderer', () => {
     });
 
     it('should work for deletions', () => {
+      const file = {
+        addedLines: 12,
+        deletedLines: 41,
+        language: 'js',
+        oldName: 'my/file/name.js',
+        newName: 'my/file/name.js',
+        isCombined: false,
+        isGitDiff: false,
+        blocks: [],
+      };
       const hoganUtils = new HoganJsUtils({});
       const lineByLineRenderer = new LineByLineRenderer(hoganUtils, {});
-      const fileHtml = lineByLineRenderer.generateSingleLineHtml({
+      const fileHtml = lineByLineRenderer.generateSingleLineHtml(file, {
         type: CSSLineClass.DELETES,
         prefix: '-',
         content: 'test',
@@ -75,9 +95,19 @@ describe('LineByLineRenderer', () => {
     });
 
     it('should convert indents into non breakin spaces (2 white spaces)', () => {
+      const file = {
+        addedLines: 12,
+        deletedLines: 41,
+        language: 'js',
+        oldName: 'my/file/name.js',
+        newName: 'my/file/name.js',
+        isCombined: false,
+        isGitDiff: false,
+        blocks: [],
+      };
       const hoganUtils = new HoganJsUtils({});
       const lineByLineRenderer = new LineByLineRenderer(hoganUtils, {});
-      const fileHtml = lineByLineRenderer.generateSingleLineHtml({
+      const fileHtml = lineByLineRenderer.generateSingleLineHtml(file, {
         type: CSSLineClass.INSERTS,
         prefix: '+',
         content: '  test',
@@ -101,9 +131,19 @@ describe('LineByLineRenderer', () => {
     });
 
     it('should convert indents into non breakin spaces (4 white spaces)', () => {
+      const file = {
+        addedLines: 12,
+        deletedLines: 41,
+        language: 'js',
+        oldName: 'my/file/name.js',
+        newName: 'my/file/name.js',
+        isCombined: false,
+        isGitDiff: false,
+        blocks: [],
+      };
       const hoganUtils = new HoganJsUtils({});
       const lineByLineRenderer = new LineByLineRenderer(hoganUtils, {});
-      const fileHtml = lineByLineRenderer.generateSingleLineHtml({
+      const fileHtml = lineByLineRenderer.generateSingleLineHtml(file, {
         type: CSSLineClass.INSERTS,
         prefix: '+',
         content: '    test',
@@ -127,9 +167,19 @@ describe('LineByLineRenderer', () => {
     });
 
     it('should preserve tabs', () => {
+      const file = {
+        addedLines: 12,
+        deletedLines: 41,
+        language: 'js',
+        oldName: 'my/file/name.js',
+        newName: 'my/file/name.js',
+        isCombined: false,
+        isGitDiff: false,
+        blocks: [],
+      };
       const hoganUtils = new HoganJsUtils({});
       const lineByLineRenderer = new LineByLineRenderer(hoganUtils, {});
-      const fileHtml = lineByLineRenderer.generateSingleLineHtml({
+      const fileHtml = lineByLineRenderer.generateSingleLineHtml(file, {
         type: CSSLineClass.INSERTS,
         prefix: '+',
         content: '\ttest',

--- a/src/line-by-line-renderer.ts
+++ b/src/line-by-line-renderer.ts
@@ -103,14 +103,14 @@ export default class LineByLineRenderer {
         this.applyLineGroupping(block).forEach(([contextLines, oldLines, newLines]) => {
           if (oldLines.length && newLines.length && !contextLines.length) {
             this.applyRematchMatching(oldLines, newLines, matcher).map(([oldLines, newLines]) => {
-              const { left, right } = this.processChangedLines(file.isCombined, oldLines, newLines);
+              const { left, right } = this.processChangedLines(file, file.isCombined, oldLines, newLines);
               lines += left;
               lines += right;
             });
           } else if (contextLines.length) {
             contextLines.forEach(line => {
               const { prefix, content } = renderUtils.deconstructLine(line.content, file.isCombined);
-              lines += this.generateSingleLineHtml({
+              lines += this.generateSingleLineHtml(file, {
                 type: renderUtils.CSSLineClass.CONTEXT,
                 prefix: prefix,
                 content: content,
@@ -119,7 +119,7 @@ export default class LineByLineRenderer {
               });
             });
           } else if (oldLines.length || newLines.length) {
-            const { left, right } = this.processChangedLines(file.isCombined, oldLines, newLines);
+            const { left, right } = this.processChangedLines(file, file.isCombined, oldLines, newLines);
             lines += left;
             lines += right;
           } else {
@@ -188,7 +188,7 @@ export default class LineByLineRenderer {
     return doMatching ? matcher(oldLines, newLines) : [[oldLines, newLines]];
   }
 
-  processChangedLines(isCombined: boolean, oldLines: DiffLine[], newLines: DiffLine[]): FileHtml {
+  processChangedLines(file: DiffFile, isCombined: boolean, oldLines: DiffLine[], newLines: DiffLine[]): FileHtml {
     const fileHtml = {
       right: '',
       left: '',
@@ -240,7 +240,7 @@ export default class LineByLineRenderer {
             }
           : undefined;
 
-      const { left, right } = this.generateLineHtml(preparedOldLine, preparedNewLine);
+      const { left, right } = this.generateLineHtml(file, preparedOldLine, preparedNewLine);
       fileHtml.left += left;
       fileHtml.right += right;
     }
@@ -248,14 +248,14 @@ export default class LineByLineRenderer {
     return fileHtml;
   }
 
-  generateLineHtml(oldLine?: DiffPreparedLine, newLine?: DiffPreparedLine): FileHtml {
+  generateLineHtml(file: DiffFile, oldLine?: DiffPreparedLine, newLine?: DiffPreparedLine): FileHtml {
     return {
-      left: this.generateSingleLineHtml(oldLine),
-      right: this.generateSingleLineHtml(newLine),
+      left: this.generateSingleLineHtml(file, oldLine),
+      right: this.generateSingleLineHtml(file, newLine),
     };
   }
 
-  generateSingleLineHtml(line?: DiffPreparedLine): string {
+  generateSingleLineHtml(file: DiffFile, line?: DiffPreparedLine): string {
     if (line === undefined) return '';
 
     const lineNumberHtml = this.hoganUtils.render(baseTemplatesPath, 'numbers', {
@@ -270,6 +270,8 @@ export default class LineByLineRenderer {
       prefix: line.prefix === ' ' ? '&nbsp;' : line.prefix,
       content: line.content,
       lineNumber: lineNumberHtml,
+      line,
+      file,
     });
   }
 }


### PR DESCRIPTION
This PR hands in the file and line objects into the "generic-line" template as variable. See [this issue](https://github.com/rtfpessoa/diff2html/issues/480) for more context.

Some of the questions here include:
* are the tests enough like this or should we add tests for overwriting templates which consume these variables?
* Should we hand in the "main entity" (or entities) to other templates as well? (I only needed the file/line in the generic line template)

Thanks again for being friendly and open about my issue and proposal! :-)