### PR TITLE
GitHub-ify Generated HTML

### DIFF
--- a/src/line-by-line-renderer.ts
+++ b/src/line-by-line-renderer.ts
@@ -76,15 +76,20 @@ export default class LineByLineRenderer {
           fileTag: fileTagTemplate,
         },
       ),
+      overflowClass: this.config.diffOverflow.concat('-overflow'),
     });
   }
 
   generateEmptyDiff(): string {
-    return this.hoganUtils.render(genericTemplatesPath, 'empty-diff', {
-      contentClass: 'd2h-code-line',
-      colspan: '2',
-      CSSLineClass: renderUtils.CSSLineClass,
-    });
+    return (
+      '<tr' +
+      this.hoganUtils.render(genericTemplatesPath, 'empty-diff', {
+        contentClass: 'd2h-code-line',
+        colspan: '2',
+        CSSLineClass: renderUtils.CSSLineClass,
+      }) +
+      '</tr>'
+    );
   }
 
   generateFileHtml(file: DiffFile): string {
@@ -253,17 +258,17 @@ export default class LineByLineRenderer {
           : undefined;
 
       const { left, right } = this.generateLineHtml(preparedOldLine, preparedNewLine);
-      fileHtml.left.push(...left);
-      fileHtml.right.push(...right);
+      fileHtml.left.push(left);
+      fileHtml.right.push(right);
     }
 
     return fileHtml;
   }
 
-  generateLineHtml(oldLine?: DiffPreparedLine, newLine?: DiffPreparedLine): FileHtml {
+  generateLineHtml(oldLine?: DiffPreparedLine, newLine?: DiffPreparedLine): LineHtml {
     return {
-      left: [this.generateSingleLineHtml(oldLine)],
-      right: [this.generateSingleLineHtml(newLine)],
+      left: this.generateSingleLineHtml(oldLine),
+      right: this.generateSingleLineHtml(newLine),
     };
   }
 
@@ -305,6 +310,11 @@ type DiffPreparedLine = {
   content: string;
   oldNumber?: number;
   newNumber?: number;
+};
+
+type LineHtml = {
+  left: string;
+  right: string;
 };
 
 type FileHtml = {

--- a/src/line-by-line-renderer.ts
+++ b/src/line-by-line-renderer.ts
@@ -123,20 +123,6 @@ export default class LineByLineRenderer {
             contextLines.forEach(line => {
               const { prefix, content } = renderUtils.deconstructLine(line.content, file.isCombined);
               lines.push(
-                this.generateSingleLineHtml({
-                  type: renderUtils.CSSLineClass.CONTEXT,
-                  prefix: prefix,
-                  content: content,
-                  oldNumber: line.oldNumber,
-                  newNumber: line.newNumber,
-                }),
-              );
-            });
-          } else if (oldLines.length || newLines.length) {
-            const { left, right } = this.processChangedLines(file.isCombined, oldLines, newLines);
-            lines.push(...left);
-            lines.push(...right);
-              lines.push(
                 this.generateSingleLineHtml(file, {
                   type: renderUtils.CSSLineClass.CONTEXT,
                   prefix: prefix,
@@ -218,7 +204,6 @@ export default class LineByLineRenderer {
 
     return doMatching ? matcher(oldLines, newLines) : [[oldLines, newLines]];
   }
-
 
   processChangedLines(file: DiffFile, isCombined: boolean, oldLines: DiffLine[], newLines: DiffLine[]): FileHtml {
     const fileHtml: FileHtml = {
@@ -307,7 +292,6 @@ export default class LineByLineRenderer {
       contentClass: 'd2h-code-line',
       prefix: line.prefix === ' ' ? '&nbsp;' : line.prefix,
       content: line.content,
-      lineNumber: lineNumberHtml,
       line,
       file,
     });

--- a/src/render-utils.ts
+++ b/src/render-utils.ts
@@ -2,7 +2,15 @@ import * as jsDiff from 'diff';
 
 import { unifyPath, hashCode } from './utils';
 import * as rematch from './rematch';
-import { LineMatchingType, DiffStyleType, LineType, DiffLineParts, DiffFile, DiffFileName } from './types';
+import {
+  LineMatchingType,
+  DiffStyleType,
+  DiffOverflowType,
+  LineType,
+  DiffLineParts,
+  DiffFile,
+  DiffFileName,
+} from './types';
 
 export type CSSLineClass =
   | 'd2h-ins'
@@ -37,6 +45,7 @@ export interface RenderConfig {
   matchWordsThreshold?: number;
   maxLineLengthHighlight?: number;
   diffStyle?: DiffStyleType;
+  diffOverflow?: DiffOverflowType;
 }
 
 export const defaultRenderConfig = {
@@ -44,6 +53,7 @@ export const defaultRenderConfig = {
   matchWordsThreshold: 0.25,
   maxLineLengthHighlight: 10000,
   diffStyle: DiffStyleType.WORD,
+  diffOverflow: DiffOverflowType.SCROLL,
 };
 
 const separator = '/';

--- a/src/side-by-side-renderer.ts
+++ b/src/side-by-side-renderer.ts
@@ -4,6 +4,7 @@ import * as renderUtils from './render-utils';
 import {
   DiffLine,
   LineType,
+  DiffOverflowType,
   DiffFile,
   DiffBlock,
   DiffLineContext,
@@ -42,26 +43,42 @@ export default class SideBySideRenderer {
   render(diffFiles: DiffFile[]): string {
     const diffsHtml = diffFiles
       .map(file => {
-        let diffs;
+        let diffsFileHtml;
         if (file.blocks.length) {
-          diffs = this.generateFileHtml(file);
+          diffsFileHtml = this.generateFileHtml(file);
         } else {
-          diffs = this.generateEmptyDiff();
+          diffsFileHtml = this.generateEmptyDiff();
         }
-        return this.makeFileDiffHtml(file, diffs);
+        return this.makeFileDiffHtml(file, diffsFileHtml);
       })
       .join('\n');
 
     return this.hoganUtils.render(genericTemplatesPath, 'wrapper', { content: diffsHtml });
   }
 
-  makeFileDiffHtml(file: DiffFile, diffs: string): string {
+  makeFileDiffHtml(file: DiffFile, diffsFileHtml: FileHtml): string {
     if (this.config.renderNothingWhenEmpty && Array.isArray(file.blocks) && file.blocks.length === 0) return '';
 
-    const fileDiffTemplate = this.hoganUtils.template(baseTemplatesPath, 'file-diff');
+    if (this.config.diffOverflow === DiffOverflowType.SCROLL) {
+      return this.makeScrollFileDiffHtml(file, diffsFileHtml);
+    }
+
+    if (this.config.diffOverflow === DiffOverflowType.WRAP) {
+      return this.makeWrappedFileDiffHtml(file, diffsFileHtml);
+    }
+
+    throw new Error('Unrecognised DiffOverflow setting');
+  }
+
+  makeWrappedFileDiffHtml(file: DiffFile, diffsFileHtml: FileHtml): string {
+    if (this.config.renderNothingWhenEmpty && Array.isArray(file.blocks) && file.blocks.length === 0) return '';
+
+    const fileDiffTemplate = this.hoganUtils.template(baseTemplatesPath, 'text-wrapped-file-diff');
     const filePathTemplate = this.hoganUtils.template(genericTemplatesPath, 'file-path');
     const fileIconTemplate = this.hoganUtils.template(iconsBaseTemplatesPath, 'file');
     const fileTagTemplate = this.hoganUtils.template(tagsBaseTemplatesPath, renderUtils.getFileIcon(file));
+
+    const diffs = this.joinFileHtmlForWrappedDisplay(diffsFileHtml);
 
     return fileDiffTemplate.render({
       file: file,
@@ -79,15 +96,50 @@ export default class SideBySideRenderer {
     });
   }
 
-  generateEmptyDiff(): string {
-    return this.hoganUtils.render(genericTemplatesPath, 'empty-diff', {
-      contentClass: 'd2h-code-side-line',
-      colspan: '4',
-      CSSLineClass: renderUtils.CSSLineClass,
+  makeScrollFileDiffHtml(file: DiffFile, diffsFileHtml: FileHtml): string {
+    if (this.config.renderNothingWhenEmpty && Array.isArray(file.blocks) && file.blocks.length === 0) return '';
+
+    const fileDiffTemplate = this.hoganUtils.template(baseTemplatesPath, 'file-diff');
+    const filePathTemplate = this.hoganUtils.template(genericTemplatesPath, 'file-path');
+    const fileIconTemplate = this.hoganUtils.template(iconsBaseTemplatesPath, 'file');
+    const fileTagTemplate = this.hoganUtils.template(tagsBaseTemplatesPath, renderUtils.getFileIcon(file));
+
+    const diffs = this.joinFileHtmlForScrollDisplay(diffsFileHtml);
+
+    return fileDiffTemplate.render({
+      file: file,
+      fileHtmlId: renderUtils.getHtmlId(file),
+      diffs: diffs,
+      filePath: filePathTemplate.render(
+        {
+          fileDiffName: renderUtils.filenameDiff(file),
+        },
+        {
+          fileIcon: fileIconTemplate,
+          fileTag: fileTagTemplate,
+        },
+      ),
     });
   }
 
-  generateFileHtml(file: DiffFile): string {
+  generateEmptyDiff(): FileHtml {
+    return {
+      left: [
+        this.hoganUtils.render(genericTemplatesPath, 'empty-diff', {
+          contentClass: 'd2h-code-side-line',
+          CSSLineClass: renderUtils.CSSLineClass,
+        }),
+      ],
+      right: [
+        this.hoganUtils.render(genericTemplatesPath, 'empty-diff', {
+          contentClass: 'd2h-code-side-line',
+          CSSLineClass: renderUtils.CSSLineClass,
+        }),
+      ],
+    };
+  }
+
+  generateFileHtml(file: DiffFile): FileHtml {
     const matcher = Rematch.newMatcherFn(
       Rematch.newDistanceFn((e: DiffLine) => renderUtils.deconstructLine(e.content, file.isCombined).content),
     );
@@ -95,9 +147,12 @@ export default class SideBySideRenderer {
     return file.blocks
       .map(block => {
         const fileHtml: FileHtml = {
-          left: [this.makeHeaderHtml(block.header, file)],
-          right: [''],
+          left: [],
+          right: [],
         };
+        const header = this.makeHeaderHtml(block.header, file);
+        fileHtml.left.push(header.left);
+        fileHtml.right.push(header.right);
 
         this.applyLineGrouping(block).forEach(([contextLines, oldLines, newLines]) => {
           if (oldLines.length && newLines.length && !contextLines.length) {
@@ -123,8 +178,8 @@ export default class SideBySideRenderer {
                   number: line.newNumber,
                 },
               );
-              fileHtml.left.push(...left);
-              fileHtml.right.push(...right);
+              fileHtml.left.push(left);
+              fileHtml.right.push(right);
             });
           } else if (oldLines.length || newLines.length) {
             const { left, right } = this.processChangedLines(file.isCombined, oldLines, newLines);
@@ -137,16 +192,36 @@ export default class SideBySideRenderer {
 
         return fileHtml;
       })
-      .map((block_html: FileHtml) => {
-        let block_html_string = '';
-        for (let block_line_index = 0; block_line_index < block_html.left.length; block_line_index++) {
-          block_html_string = block_html_string.concat(
-            `<tr>${block_html.left[block_line_index]} ${block_html.right[block_line_index]}</tr>`,
-          );
-        }
-        return block_html_string;
-      })
-      .join('\n');
+      .reduce(
+        (accumulator: FileHtml, { left, right }) => {
+          accumulator.left.push(...left);
+          accumulator.right.push(...right);
+          return accumulator;
+        },
+        { left: [], right: [] },
+      );
+  }
+
+  joinFileHtmlForWrappedDisplay(fileHtml: FileHtml): string {
+    let joined_string = '';
+    for (let block_line_index = 0; block_line_index < fileHtml.left.length; block_line_index++) {
+      joined_string = joined_string.concat(
+        `<tr>${fileHtml.left[block_line_index]} ${fileHtml.right[block_line_index]}</tr>\n`,
+      );
+    }
+    return joined_string;
+  }
+
+  joinFileHtmlForScrollDisplay(fileHtml: FileHtml): { left: string; right: string } {
+    const joined_strings = {
+      left: '',
+      right: '',
+    };
+    for (let block_line_index = 0; block_line_index < fileHtml.left.length; block_line_index++) {
+      joined_strings.left = joined_strings.left.concat(`<tr>${fileHtml.left[block_line_index]}</tr>\n`);
+      joined_strings.right = joined_strings.right.concat(`<tr>${fileHtml.right[block_line_index]}</tr>\n`);
+    }
+    return joined_strings;
   }
 
   applyLineGrouping(block: DiffBlock): DiffLineGroups {
@@ -205,8 +280,40 @@ export default class SideBySideRenderer {
     return doMatching ? matcher(oldLines, newLines) : [[oldLines, newLines]];
   }
 
-  makeHeaderHtml(blockHeader: string, file?: DiffFile): string {
-    return this.hoganUtils.render(genericTemplatesPath, 'block-header', {
+  makeHeaderHtml(blockHeader: string, file?: DiffFile): LineHtml {
+    if (this.config.diffOverflow === DiffOverflowType.WRAP) {
+      return this.makeWrappedHeaderHtml(blockHeader, file);
+    }
+
+    if (this.config.diffOverflow === DiffOverflowType.SCROLL) {
+      return this.makeScrollHeaderHtml(blockHeader, file);
+    }
+
+    throw new Error('Unrecognised DiffOverflow setting');
+  }
+
+  makeScrollHeaderHtml(blockHeader: string, file?: DiffFile): LineHtml {
+    const left = this.hoganUtils.render(genericTemplatesPath, 'block-header', {
+      CSSLineClass: renderUtils.CSSLineClass,
+      margin_colspan: '1',
+      colspan: '1',
+      blockHeader: file?.isTooBig ? blockHeader : renderUtils.escapeForHtml(blockHeader),
+      lineClass: 'd2h-code-side-linenumber',
+      contentClass: 'd2h-code-side-line',
+    });
+
+    const right = this.hoganUtils.render(genericTemplatesPath, 'block-header', {
+      CSSLineClass: renderUtils.CSSLineClass,
+      margin_colspan: '1',
+      colspan: '1',
+      lineClass: 'd2h-code-side-linenumber',
+      contentClass: 'd2h-code-side-line',
+    });
+    return { left, right };
+  }
+
+  makeWrappedHeaderHtml(blockHeader: string, file?: DiffFile): LineHtml {
+    const table_element = this.hoganUtils.render(genericTemplatesPath, 'block-header', {
       CSSLineClass: renderUtils.CSSLineClass,
       margin_colspan: '1',
       colspan: '3',
@@ -214,6 +321,10 @@ export default class SideBySideRenderer {
       lineClass: 'd2h-code-side-linenumber',
       contentClass: 'd2h-code-side-line',
     });
+    return {
+      left: table_element,
+      right: '',
+    };
   }
 
   processChangedLines(isCombined: boolean, oldLines: DiffLine[], newLines: DiffLine[]): FileHtml {
@@ -267,17 +378,17 @@ export default class SideBySideRenderer {
           : undefined;
 
       const { left, right } = this.generateLineHtml(preparedOldLine, preparedNewLine);
-      fileHtml.left.push(...left);
-      fileHtml.right.push(...right);
+      fileHtml.left.push(left);
+      fileHtml.right.push(right);
     }
 
     return fileHtml;
   }
 
-  generateLineHtml(oldLine?: DiffPreparedLine, newLine?: DiffPreparedLine): FileHtml {
+  generateLineHtml(oldLine?: DiffPreparedLine, newLine?: DiffPreparedLine): LineHtml {
     return {
-      left: [this.generateSingleHtml(oldLine)],
-      right: [this.generateSingleHtml(newLine)],
+      left: this.generateSingleHtml(oldLine),
+      right: this.generateSingleHtml(newLine),
     };
   }
 
@@ -315,6 +426,11 @@ type DiffPreparedLine = {
   prefix: string;
   content: string;
   number: number;
+};
+
+type LineHtml = {
+  left: string;
+  right: string;
 };
 
 type FileHtml = {

--- a/src/templates/generic-block-header.mustache
+++ b/src/templates/generic-block-header.mustache
@@ -1,6 +1,4 @@
-<tr>
-    <td class="{{lineClass}} {{CSSLineClass.INFO}}"></td>
-    <td class="{{CSSLineClass.INFO}}">
-        <div class="{{contentClass}}">{{#blockHeader}}{{{blockHeader}}}{{/blockHeader}}{{^blockHeader}}&nbsp;{{/blockHeader}}</div>
-    </td>
-</tr>
+<td class="{{lineClass}} {{CSSLineClass.INFO}}" colspan="{{margin_colspan}}"></td>
+<td class="{{CSSLineClass.INFO}}" colspan="{{colspan}}">
+    <div class="{{contentClass}}">{{#blockHeader}}{{{blockHeader}}}{{/blockHeader}}{{^blockHeader}}&nbsp;{{/blockHeader}}</div>
+</td>

--- a/src/templates/generic-empty-diff.mustache
+++ b/src/templates/generic-empty-diff.mustache
@@ -1,7 +1,7 @@
 <tr>
-    <td class="{{CSSLineClass.INFO}}">
-        <div class="{{contentClass}}">
-            File without changes
-        </div>
-    </td>
+  <td class="{{CSSLineClass.INFO}}" colspan="{{#colspan}}{{{.}}}{{/colspan}}{{^colspan}}2{{/colspan}}">
+      <div class="{{contentClass}}">
+          File without changes
+      </div>
+  </td>
 </tr>

--- a/src/templates/generic-empty-diff.mustache
+++ b/src/templates/generic-empty-diff.mustache
@@ -1,7 +1,5 @@
-<tr>
-  <td class="{{CSSLineClass.INFO}}" colspan="{{#colspan}}{{{.}}}{{/colspan}}{{^colspan}}2{{/colspan}}">
-      <div class="{{contentClass}}">
-          File without changes
-      </div>
-  </td>
-</tr>
+<td class="{{CSSLineClass.INFO}}" colspan="{{#colspan}}{{{colspan}}}{{/colspan}}{{^colspan}}2{{/colspan}}">
+    <div class="{{contentClass}}">
+        File without changes
+    </div>
+</td>

--- a/src/templates/generic-line-number.mustache
+++ b/src/templates/generic-line-number.mustache
@@ -1,0 +1,1 @@
+<td class="{{lineClass}} {{type}}" {{#lineNumber}}data-line-number="{{{lineNumber}}}"{{/lineNumber}}></td>

--- a/src/templates/generic-line.mustache
+++ b/src/templates/generic-line.mustache
@@ -1,5 +1,5 @@
 <td class="{{type}}">
     <div class="{{contentClass}}">
-    {{#prefix}}<span class="d2h-code-line-ctn d2h-code-marker" data-code-marker="{{{prefix}}}">{{/prefix}}{{^prefix}}<span class="d2h-code-line-ctn d2h-code-marker" data-code-marker=&nsbp;>{{/prefix}}{{#content}}{{content}}</span>{{/content}}{{^content}}<br></span>{{/content}}
+    {{#prefix}}<span class="d2h-code-line-ctn d2h-code-marker" data-code-marker="{{{prefix}}}">{{/prefix}}{{^prefix}}<span class="d2h-code-line-ctn d2h-code-marker" data-code-marker="&nbsp;">{{/prefix}}{{#content}}{{{content}}}</span>{{/content}}{{^content}}<br></span>{{/content}}
     </div>
 </td>

--- a/src/templates/generic-line.mustache
+++ b/src/templates/generic-line.mustache
@@ -1,21 +1,5 @@
-<tr>
-    <td class="{{lineClass}} {{type}}">
-      {{{lineNumber}}}
-    </td>
-    <td class="{{type}}">
-        <div class="{{contentClass}}">
-        {{#prefix}}
-            <span class="d2h-code-line-prefix">{{{prefix}}}</span>
-        {{/prefix}}
-        {{^prefix}}
-            <span class="d2h-code-line-prefix">&nbsp;</span>
-        {{/prefix}}
-        {{#content}}
-            <span class="d2h-code-line-ctn">{{{content}}}</span>
-        {{/content}}
-        {{^content}}
-            <span class="d2h-code-line-ctn"><br></span>
-        {{/content}}
-        </div>
-    </td>
-</tr>
+<td class="{{type}}">
+    <div class="{{contentClass}}">
+    {{#prefix}}<span class="d2h-code-line-ctn d2h-code-marker" data-code-marker="{{{prefix}}}">{{/prefix}}{{^prefix}}<span class="d2h-code-line-ctn d2h-code-marker" data-code-marker=&nsbp;>{{/prefix}}{{#content}}{{content}}</span>{{/content}}{{^content}}<br></span>{{/content}}
+    </div>
+</td>

--- a/src/templates/line-by-line-file-diff.mustache
+++ b/src/templates/line-by-line-file-diff.mustache
@@ -2,7 +2,7 @@
     <div class="d2h-file-header">
     {{{filePath}}}
     </div>
-    <div class="d2h-file-diff">
+    <div class="d2h-file-diff {{overflowClass}}">
         <div class="d2h-code-wrapper">
             <table class="d2h-diff-table">
                 <thead hidden>

--- a/src/templates/line-by-line-file-diff.mustache
+++ b/src/templates/line-by-line-file-diff.mustache
@@ -5,6 +5,14 @@
     <div class="d2h-file-diff">
         <div class="d2h-code-wrapper">
             <table class="d2h-diff-table">
+                <thead hidden>
+                    <tr>
+                        <th scope="col">Original file line number</th>
+                        <th scope="col">Diff line number</th>
+                        <th scope="col">Content</th>
+                    </tr>
+                </thead>
+
                 <tbody class="d2h-diff-tbody">
                 {{{diffs}}}
                 </tbody>

--- a/src/templates/line-by-line-numbers.mustache
+++ b/src/templates/line-by-line-numbers.mustache
@@ -1,2 +1,0 @@
-<div class="line-num1">{{oldNumber}}</div>
-<div class="line-num2">{{newNumber}}</div>

--- a/src/templates/side-by-side-file-diff.mustache
+++ b/src/templates/side-by-side-file-diff.mustache
@@ -5,18 +5,25 @@
     <div class="d2h-files-diff">
         <div class="d2h-file-side-diff">
             <div class="d2h-code-wrapper">
-                <table class="d2h-diff-table">
+                <table class="d2h-diff-table d2h-split-diff">
+                    <thead hidden>
+                        <tr>
+                            <th scope="col">Original file line number</th>
+                            <th scope="col">Original file content</th>
+                            <th scope="col">Diff line number</th>
+                            <th scope="col">Diff content</th>
+                        </tr>
+                    </thead>
+
+                    <colgroup>
+                        <col width="40">
+                        <col>
+                        <col width="40">
+                        <col>
+                    </colgroup>
+
                     <tbody class="d2h-diff-tbody">
-                    {{{diffs.left}}}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="d2h-file-side-diff">
-            <div class="d2h-code-wrapper">
-                <table class="d2h-diff-table">
-                    <tbody class="d2h-diff-tbody">
-                    {{{diffs.right}}}
+                    {{{diffs}}}
                     </tbody>
                 </table>
             </div>

--- a/src/templates/side-by-side-text-wrapped-file-diff.mustache
+++ b/src/templates/side-by-side-text-wrapped-file-diff.mustache
@@ -3,32 +3,13 @@
       {{{filePath}}}
     </div>
     <div class="d2h-files-diff">
-        <div class="d2h-file-side-diff scroll-overflow">
+        <div class="d2h-file-side-diff wrap-overflow">
             <div class="d2h-code-wrapper">
                 <table class="d2h-diff-table d2h-split-diff">
                     <thead hidden>
                         <tr>
                             <th scope="col">Original file line number</th>
                             <th scope="col">Original file content</th>
-                        </tr>
-                    </thead>
-
-                    <colgroup>
-                        <col style="width: 40px;">
-                        <col>
-                    </colgroup>
-
-                    <tbody class="d2h-diff-tbody">
-                    {{{diffs.left}}}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="d2h-file-side-diff scroll-overflow">
-            <div class="d2h-code-wrapper">
-                <table class="d2h-diff-table d2h-split-diff">
-                    <thead hidden>
-                        <tr>
                             <th scope="col">Diff line number</th>
                             <th scope="col">Diff content</th>
                         </tr>
@@ -37,10 +18,12 @@
                     <colgroup>
                         <col style="width: 40px;">
                         <col>
+                        <col style="width: 40px;">
+                        <col>
                     </colgroup>
 
                     <tbody class="d2h-diff-tbody">
-                    {{{diffs.right}}}
+                    {{{diffs}}}
                     </tbody>
                 </table>
             </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,3 +91,10 @@ export const DiffStyleType: { [_: string]: DiffStyleType } = {
   WORD: 'word',
   CHAR: 'char',
 };
+
+export type DiffOverflowType = 'scroll' | 'wrap';
+
+export const DiffOverflowType: { [_: string]: DiffOverflowType } = {
+  SCROLL: 'scroll',
+  WRAP: 'wrap',
+};

--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -30,7 +30,7 @@
 .d2h-file-header.d2h-sticky-header {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 10;
 }
 
 .d2h-file-stats {
@@ -104,13 +104,20 @@
 
 .d2h-diff-table {
   width: 100%;
-  border-collapse: separate;
   font-family: 'Menlo', 'Consolas', monospace;
   font-size: 13px;
   word-wrap: break-word;
 }
 
-.d2h-diff-table.d2h-split-diff {
+.scroll-overflow .d2h-diff-table {
+  border-collapse: collapse;
+}
+
+.wrap-overflow .d2h-diff-table {
+  border-collapse: separate;
+}
+
+.wrap-overflow .d2h-diff-table.d2h-split-diff {
   table-layout: fixed;
 }
 
@@ -124,8 +131,10 @@
   display: none;
 }
 
-.d2h-file-side-diff {
-  width: 100%;
+.d2h-file-diff.scroll-overflow,
+.d2h-file-side-diff.scroll-overflow {
+  overflow-x: scroll;
+  overflow-y: hidden;
 }
 
 .d2h-code-line,
@@ -138,6 +147,11 @@
   vertical-align: top;
 }
 
+.scroll-overflow .d2h-code-line,
+.scroll-overflow .d2h-code-side-line {
+  white-space: nowrap;
+}
+
 .d2h-code-marker::before {
   position: absolute;
   top: 1px;
@@ -146,13 +160,22 @@
   content: attr(data-code-marker);
 }
 
+.wrap-overflow .d2h-code-line-ctn {
+  word-wrap: anywhere;
+  overflow: visible;
+  white-space: pre-wrap;
+}
+
+.scroll-overflow .d2h-code-line-ctn {
+  overflow: scroll;
+}
+
 .d2h-code-line-ctn {
   display: table-cell;
   background: none;
   padding: 0;
-  word-wrap: anywhere;
-  white-space: pre-wrap;
-  overflow: visible;
+  word-wrap: normal;
+  white-space: pre;
   user-select: text;
   width: 100%;
   vertical-align: middle;
@@ -197,14 +220,38 @@
   content: '\200b';
 }
 
+.wrap-overflow .d2h-code-side-linenumber,
+.wrap-overflow .d2h-code-linenumber,
+.wrap-overflow .d2h-code-emptyplaceholder {
+  position: relative;
+}
+
+.scroll-overflow .d2h-code-side-linenumber,
+.scroll-overflow .d2h-code-linenumber,
+.scroll-overflow .d2h-code-emptyplaceholder {
+  position: sticky;
+  z-index: 1;
+}
+
+.scroll-overflow .d2h-code-side-linenumber {
+  left: 0;
+}
+
+.scroll-overflow.d2h-file-diff tr td:first-child {
+  left: 0;
+}
+
+.scroll-overflow.d2h-file-diff tr td:nth-child(2) {
+  left: 50px;
+}
+
 .d2h-code-side-linenumber,
 .d2h-code-linenumber {
-  /* Keep the numbers fixed on line contents scroll */
   white-space: nowrap;
-  position: relative;
   background-color: #fff;
   color: rgba(0, 0, 0, 0.3);
   text-align: right;
+  vertical-align: top;
   border: solid #eeeeee;
   border-width: 0 1px 0 1px;
   line-height: 20px;

--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -7,6 +7,17 @@
 
 .d2h-wrapper {
   text-align: left;
+  word-wrap: break-word;
+}
+
+.d2h-wrapper * {
+  box-sizing: border-box;
+}
+
+.d2h-wrapper table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  table-layout: fixed;
 }
 
 .d2h-file-header {
@@ -94,18 +105,19 @@
 
 .d2h-diff-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
   font-family: 'Menlo', 'Consolas', monospace;
   font-size: 13px;
+  word-wrap: break-word;
+}
+
+.d2h-diff-table.d2h-split-diff {
+  table-layout: fixed;
 }
 
 .d2h-files-diff {
   display: flex;
   width: 100%;
-}
-
-.d2h-file-diff {
-  overflow-y: hidden;
 }
 
 .d2h-files-diff.d2h-d-none,
@@ -114,36 +126,34 @@
 }
 
 .d2h-file-side-diff {
-  display: inline-block;
-  overflow-x: scroll;
-  overflow-y: hidden;
-  width: 50%;
+  width: 100%;
 }
 
-.d2h-code-line {
-  display: inline-block;
-  white-space: nowrap;
-  user-select: none;
-  width: calc(100% - 16em);
-  /* Compensate for the absolute positioning of the line numbers */
-  padding: 0 8em;
-}
-
+.d2h-code-line,
 .d2h-code-side-line {
-  display: inline-block;
-  white-space: nowrap;
   user-select: none;
-  width: calc(100% - 9em);
-  /* Compensate for the absolute positioning of the line numbers */
-  padding: 0 4.5em;
+  padding-left: 22px;
+  position: relative;
+  padding-right: 10px;
+  line-height: 20px;
+  vertical-align: top;
+}
+
+.d2h-code-marker::before {
+  position: absolute;
+  top: 1px;
+  left: 8px;
+  padding-right: 8px;
+  content: attr(data-code-marker);
 }
 
 .d2h-code-line-ctn {
-  display: inline-block;
+  display: table-cell;
   background: none;
   padding: 0;
-  word-wrap: normal;
-  white-space: pre;
+  word-wrap: anywhere;
+  white-space: pre-wrap;
+  overflow: visible;
   user-select: text;
   width: 100%;
   vertical-align: middle;
@@ -178,61 +188,31 @@
   white-space: pre;
 }
 
-.line-num1 {
-  box-sizing: border-box;
-  float: left;
-  width: 3.5em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  padding: 0 0.5em 0 0.5em;
+.d2h-code-linenumber::before,
+.d2h-code-side-linenumber::before {
+  content: attr(data-line-number);
 }
 
-.line-num2 {
-  box-sizing: border-box;
-  float: right;
-  width: 3.5em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  padding: 0 0.5em 0 0.5em;
-}
-
-.d2h-code-linenumber {
-  box-sizing: border-box;
-  width: 7.5em;
-  /* Keep the numbers fixed on line contents scroll */
-  position: absolute;
-  display: inline-block;
-  background-color: #fff;
-  color: rgba(0, 0, 0, 0.3);
-  text-align: right;
-  border: solid #eeeeee;
-  border-width: 0 1px 0 1px;
-  cursor: pointer;
-}
-
-.d2h-code-linenumber:after {
-  content: '\200b';
-}
-
-.d2h-code-side-linenumber {
-  /* Keep the numbers fixed on line contents scroll */
-  position: absolute;
-  display: inline-block;
-  box-sizing: border-box;
-  width: 4em;
-  background-color: #fff;
-  color: rgba(0, 0, 0, 0.3);
-  text-align: right;
-  border: solid #eeeeee;
-  border-width: 0 1px 0 1px;
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  padding: 0 0.5em 0 0.5em;
-}
-
+.d2h-code-linenumber:after,
 .d2h-code-side-linenumber:after {
   content: '\200b';
+}
+
+.d2h-code-side-linenumber,
+.d2h-code-linenumber {
+  /* Keep the numbers fixed on line contents scroll */
+  position: relative;
+  background-color: #fff;
+  color: rgba(0, 0, 0, 0.3);
+  text-align: right;
+  border: solid #eeeeee;
+  border-width: 0 1px 0 1px;
+  line-height: 20px;
+  font-size: 12px;
+  width: 1%;
+  min-width: 50px;
+  padding-right: 10px;
+  padding-left: 10px;
 }
 
 .d2h-code-side-emptyplaceholder,

--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -17,7 +17,6 @@
 .d2h-wrapper table {
   border-spacing: 0;
   border-collapse: collapse;
-  table-layout: fixed;
 }
 
 .d2h-file-header {

--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -200,6 +200,7 @@
 .d2h-code-side-linenumber,
 .d2h-code-linenumber {
   /* Keep the numbers fixed on line contents scroll */
+  white-space: nowrap;
   position: relative;
   background-color: #fff;
   color: rgba(0, 0, 0, 0.3);

--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -137,6 +137,10 @@
   overflow-y: hidden;
 }
 
+.d2h-file-side-diff {
+  width: 100%;
+}
+
 .d2h-code-line,
 .d2h-code-side-line {
   user-select: none;

--- a/src/ui/js/diff2html-ui-base.ts
+++ b/src/ui/js/diff2html-ui-base.ts
@@ -63,6 +63,8 @@ export class Diff2HtmlUI {
     this.targetElement.querySelectorAll('.d2h-file-wrapper').forEach(wrapper => {
       const [left, right] = Array<Element>().slice.call(wrapper.querySelectorAll('.d2h-file-side-diff'));
 
+      console.log(left, right);
+
       if (left === undefined || right === undefined) return;
 
       const onScroll = (event: Event): void => {


### PR DESCRIPTION
There are some notable differences in the HTML generated by `diff2html` and `GitHub`. 
These changes cause the generated HTML to be much more similar in structure to GitHub's generated structure:
- using `::before` and attribute tags for line numbers and content markers (`+`, `-`)
- using a single table element for split diff view, instead of two 
- using separate table columns for the unified diff view's line numbers

This makes applying different themes to `diff2html` using CSS overrides simpler and more effective. For example, before this change, it isn't possible to have different background colours for line numbers / line content as the line numbers don't take up the same height as the content (I should provide a screenshot, sorry 😬 )

I haven't updated the testcases to match the changes in generated structure yet - just want to check you're OK with the changes before I do.

Also, I'm sorry about the commit messages - I'm a bit of a git newbie 😓 - if you'd like me to change them and can tell me how, I'd love to fix them to comply with the contribution guidelines.