### PR TITLE
Handle case where the language is known but not loaded into HLJS

### DIFF
--- a/src/ui/js/diff2html-ui-base.ts
+++ b/src/ui/js/diff2html-ui-base.ts
@@ -151,13 +151,16 @@ export class Diff2HtmlUI {
         this.config.highlightLanguages = new Map(Object.entries(this.config.highlightLanguages));
       }
 
-      const hljsLanguage =
+      let hljsLanguage =
         language && this.config.highlightLanguages.has(language)
           ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             this.config.highlightLanguages.get(language)!
           : language
           ? getLanguage(language)
           : 'plaintext';
+      if (language !== null && hljs.getLanguage(language) === undefined) {
+        hljsLanguage = 'plaintext';
+      }
 
       // Collect all the code lines and execute the highlight on them
       const codeLines = file.querySelectorAll('.d2h-code-line-ctn');


### PR DESCRIPTION
This PR is in reference to issue #504 . What is happening is:

- Another library is using the slim version of diff2html
- [Here in getLanguage()](https://github.com/rtfpessoa/diff2html/blob/41a901694dc1f7a89de595555a6cd718cbf7e117/src/ui/js/highlight.js-helpers.ts#L653) it returns all mappings of extensions to language type
- But [here in the slim version](https://github.com/rtfpessoa/diff2html/blob/41a901694dc1f7a89de595555a6cd718cbf7e117/src/ui/js/highlight.js-slim.ts#L53C5-L53C5) not all possible language types are loaded into highlight.js (using Django as an example)
- Then [here in the base UI](https://github.com/rtfpessoa/diff2html/blob/41a901694dc1f7a89de595555a6cd718cbf7e117/src/ui/js/diff2html-ui-base.ts#L154C12-L154C12) the mapping two steps back is used to choose language type
- Now many file types are mapped, but only some are loaded into HLJS, so HLJS may be passed a file type it doesn't know about.  The result is an exception that ends up causing problems in the library that is using diff2html.

So my solution below is to check if the language is known (has a map entry), but HLJS doesn't know about it, in which case you fall back to plaintext.