### PR TITLE
fix broken link

### DIFF
--- a/website/templates/pages/index/content.handlebars
+++ b/website/templates/pages/index/content.handlebars
@@ -72,7 +72,7 @@
             <span class="button clipboard" data-clipboard-text="npm install diff2html" title="Copy">Copy</span>
         </div>
         <p>
-            <a href="https://github.com/rtfpessoa/diff2html#how-to-use" target="_blank" rel="noopener" rel="noreferrer">
+            <a href="https://github.com/rtfpessoa/diff2html#usage" target="_blank" rel="noopener" rel="noreferrer">
                 Find usage examples in the Docs
             </a>
         </p>
@@ -510,7 +510,7 @@
             <a href="https://gitter.im/rtfpessoa/diff2html" target="_blank" rel="noopener" rel="noreferrer">Gitter</a>.
             Need any help?
         </p>
-        <a href="https://github.com/rtfpessoa/diff2html#how-to-use" target="_blank" rel="noopener" rel="noreferrer">
+        <a href="https://github.com/rtfpessoa/diff2html#usage" target="_blank" rel="noopener" rel="noreferrer">
             Read more in the Docs
         </a>
     </div>

--- a/website/templates/template.handlebars
+++ b/website/templates/template.handlebars
@@ -78,7 +78,7 @@
                 <a href="https://twitter.com/rtfpessoa" target="_blank" rel="noopener" rel="noreferrer">@rtfpessoa</a>.
             </p>
             <p>
-                <a class="footer-list-link" href="https://github.com/rtfpessoa/diff2html#how-to-use" target="_blank"
+                <a class="footer-list-link" href="https://github.com/rtfpessoa/diff2html#usage" target="_blank"
                     rel="noopener" rel="noreferrer">FAQ</a>
                 -
                 <a class="footer-list-link" href="https://diff2html.xyz">diff2html</a>


### PR DESCRIPTION
The #how-to-use link was broken, so I changed it to #usage.