### PR TITLE
reorganize/rename blocks to match tested functions

### DIFF
--- a/src/__tests__/diff2html-tests.ts
+++ b/src/__tests__/diff2html-tests.ts
@@ -49,7 +49,7 @@ const jsonExample1: DiffFile[] = [
 ];
 
 describe('Diff2Html', () => {
-  describe('getJsonFromDiff', () => {
+  describe('parse', () => {
     it('should parse simple diff to json', () => {
       const diff =
         'diff --git a/sample b/sample\n' +
@@ -199,7 +199,9 @@ describe('Diff2Html', () => {
         ]
       `);
     });
+  });
 
+  describe('html', () => {
     it('should generate pretty line by line html from diff', () => {
       const result = html(diffExample1, { drawFileList: false });
       expect(result).toMatchInlineSnapshot(`


### PR DESCRIPTION
This is a minor reorganization in the `diff2html-tests.ts`.

While working on a new feature I noticed that the `describe('getJsonFromDiff', () => { /* ... */ }` block was wrapping the entire file, and seemed to have what I assume is the old name for `patch`.

I renamed that section and added a new `describe` block for the `html` section.

Decided to handle this separately from the other PR.