### PR TITLE
css: target both :root and :host to also cover usage in shadow DOM

### DIFF
--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -5,7 +5,8 @@
  *
  */
 
-:root {
+:root,
+:host {
   --d2h-bg-color: #fff;
   --d2h-border-color: #ddd;
 


### PR DESCRIPTION
Inside shadow DOM :root can't be targeted, so :host should be used here for those cases.

Solves issues #517