### PR TITLE
fix abnormal line numbers problem

### DIFF
--- a/src/ui/css/diff2html.css
+++ b/src/ui/css/diff2html.css
@@ -291,7 +291,7 @@
 
 .d2h-code-side-linenumber {
   /* Keep the numbers fixed on line contents scroll */
-  position: absolute;
+  position: inherit;
   display: inline-block;
   box-sizing: border-box;
   width: 4em;


### PR DESCRIPTION
Because the position attribute is absolute, abnormal line numbers may appear when scrolling on the difference result display page. Changing position to inherit can solve the problem.